### PR TITLE
Add simplistic path space regularization

### DIFF
--- a/src/options.hh
+++ b/src/options.hh
@@ -391,6 +391,12 @@
         "performance hit, and can make some rare scenes noisier, but " \
         "generally reduces noise significantly.", \
         false \
+    ) \
+    TR_FLOAT_OPT(regularization, \
+        "Sets the path space regularization gamma. Path regularization " \
+        "reduces noise without clamping brightness. It still causes some " \
+        "bias, but is a much less noticeable method.", \
+        0.0f, 0.0f, 10.0f \
     )
 //==============================================================================
 // END OF OPTIONS

--- a/src/path_tracer_stage.cc
+++ b/src/path_tracer_stage.cc
@@ -36,6 +36,9 @@ namespace path_tracer
         if(opt.importance_sample_envmap)
             defines["IMPORTANCE_SAMPLE_ENVMAP"];
 
+        if(opt.regularization_gamma != 0.0f)
+            defines["PATH_SPACE_REGULARIZATION"];
+
 #define TR_GBUFFER_ENTRY(name, ...)\
         if(gbuf.name) defines["USE_"+to_uppercase(#name)+"_TARGET"];
         TR_GBUFFER_ENTRIES
@@ -101,6 +104,7 @@ namespace path_tracer
         // -1 for no environment map
         int environment_proj;
         pvec4 environment_factor;
+        float regularization_gamma;
     };
 
     // The minimum maximum size for push constant buffers is 128 bytes in vulkan.
@@ -155,6 +159,7 @@ void path_tracer_stage::record_command_buffer_push_constants(
     control.russian_roulette_delta = opt.russian_roulette_delta;
     control.min_ray_dist = opt.min_ray_dist;
     control.indirect_clamping = opt.indirect_clamping;
+    control.regularization_gamma = opt.regularization_gamma;
 
     control.previous_samples = pass_index;
     control.samples = min(

--- a/src/path_tracer_stage.hh
+++ b/src/path_tracer_stage.hh
@@ -20,6 +20,7 @@ public:
         float russian_roulette_delta = 0; // 0 disables russian roulette.
         float indirect_clamping = 0; // 0 disables indirect clamping.
         bool importance_sample_envmap = true;
+        float regularization_gamma = 0.0f; // 0 disables path regularization
     };
 
     path_tracer_stage(

--- a/src/sh_path_tracer_stage.cc
+++ b/src/sh_path_tracer_stage.cc
@@ -32,6 +32,9 @@ namespace sh_path_tracer
         if(opt.importance_sample_envmap)
             defines["IMPORTANCE_SAMPLE_ENVMAP"];
 
+        if(opt.regularization_gamma != 0.0f)
+            defines["PATH_SPACE_REGULARIZATION"];
+
         switch(opt.film)
         {
         case film::POINT:
@@ -98,6 +101,7 @@ namespace sh_path_tracer
         // -1 for no environment map
         int environment_proj;
         pvec4 environment_factor;
+        float regularization_gamma;
     };
 
     // The minimum maximum size for push constant buffers is 128 bytes in vulkan.
@@ -233,6 +237,7 @@ void sh_path_tracer_stage::record_command_buffer_push_constants(
     control.russian_roulette_delta = opt.russian_roulette_delta;
     control.min_ray_dist = opt.min_ray_dist;
     control.indirect_clamping = opt.indirect_clamping;
+    control.regularization_gamma = opt.regularization_gamma;
 
     // We re-use the "previous samples" to mark how many samples to do in one
     // shader invocation. The name can't change on the shader side, since it is

--- a/src/sh_path_tracer_stage.hh
+++ b/src/sh_path_tracer_stage.hh
@@ -20,6 +20,7 @@ public:
         float temporal_ratio = 0.02f;
         float indirect_clamping = 100.0f;
         bool importance_sample_envmap = true;
+        float regularization_gamma = 1.0f; // 0 disables path regularization
 
         int sh_grid_index = 0;
         int sh_order = 2;

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -409,6 +409,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
                 rt_opt.importance_sample_envmap =
                     s.get_environment_map() &&
                     opt.importance_sample_envmap;
+                rt_opt.regularization_gamma = opt.regularization;
                 rt_opt.post_process.tonemap = tonemap;
                 if(opt.temporal_reprojection > 0.0f)
                     rt_opt.post_process.temporal_reprojection =
@@ -480,6 +481,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
                 sh.importance_sample_envmap =
                     s.get_environment_map() &&
                     opt.importance_sample_envmap;
+                sh.regularization_gamma = opt.regularization;
                 dr_opt.sh_source = sh;
                 dr_opt.sh_order = opt.sh_order;
                 dr_opt.use_probe_visibility = opt.use_probe_visibility;


### PR DESCRIPTION
I used a method based on what was described in ["Optimized Path Space Regularization"](https://doi.org/10.1111/cgf.14347), with constant gamma (which is set with the `--regularization` parameter), since it seems to work pretty well and is really lightweight to implement. We also apply it to both NEE and BSDF sampling, so that's another difference to the paper.