### PR TITLE
Sampling fixes

### DIFF
--- a/shader/ggx.glsl
+++ b/shader/ggx.glsl
@@ -261,7 +261,7 @@ vec3 ggx_vndf_sample(
 // https://hal.inria.fr/hal-00996995v1/document
 // http://www.graphics.cornell.edu/~bjw/microfacetbsdf.pdf
 void ggx_bsdf_sample(
-    vec3 uniform_random,
+    vec4 uniform_random,
     vec3 view_dir,
     sampled_material mat,
     out vec3 out_dir,
@@ -330,7 +330,8 @@ void ggx_bsdf_sample(
         u = clamp((u - specular_cutoff)/(1 - specular_cutoff), 0.0f, 0.99999f);
         if(u <= diffuse_cutoff)
         { // Diffuse
-            out_dir = sample_cosine_hemisphere(uniform_random.xy);
+            u = clamp(u/diffuse_cutoff, 0.0f, 0.99999f);
+            out_dir = sample_cosine_hemisphere(vec2(u, uniform_random.w));
             // The half-vector is no longer related to the one from earlier;
             // this is why we recalculate a bunch of variables here.
             h = normalize(view_dir + out_dir);

--- a/shader/path_tracer.glsl
+++ b/shader/path_tracer.glsl
@@ -554,7 +554,7 @@ void evaluate_ray(
         vec3 diffuse_weight = vec3(1.0f);
         vec3 specular_weight = vec3(1.0f);
         vec4 ray_sample = generate_ray_sample(lsampler, bounce);
-        ggx_bsdf_sample(ray_sample.xyz, shading_view, mat, view, diffuse_weight, specular_weight, bsdf_pdf);
+        ggx_bsdf_sample(ray_sample, shading_view, mat, view, diffuse_weight, specular_weight, bsdf_pdf);
         view = tbn * view;
 
         shadow_terminator_fix(diffuse_weight, specular_weight, dot(view, v.mapped_normal), mat);

--- a/shader/path_tracer.glsl
+++ b/shader/path_tracer.glsl
@@ -122,7 +122,7 @@ vec3 sample_environment_map(
     }
     else
     {
-        pdf = 4.0f * M_PI;
+        pdf = 1.0f / (4.0f * M_PI);
         shadow_ray_direction = sample_sphere(ldexp(vec2(rand), ivec2(-32)));
     }
     shadow_ray_length = RAY_MAX_DIST;
@@ -139,7 +139,7 @@ float sample_environment_map_pdf(vec3 dir)
         alias_table_entry at = environment_map_alias_table.entries[i];
         return at.pdf;
     }
-    else return 4.0f * M_PI;
+    else return 1.0f / (4.0f * M_PI);
 }
 #endif
 

--- a/src/environment_map.cc
+++ b/src/environment_map.cc
@@ -113,11 +113,15 @@ void environment_map::generate_alias_table()
         }
     }
 
-    // Write inverse pdfs.
+    std::vector<float> sin_theta(size.y);
+    for(int i = 0; i < size.y; ++i)
+        sin_theta[i] = sin((i+0.5f) / float(size.y) * M_PI);
+    // Write pdfs.
     for(unsigned i = 0; i < pixel_count; ++i)
     {
-        alias_table[i].pdf = importance[i] / (4.0f * M_PI);
-        alias_table[i].alias_pdf = importance[alias_table[i].alias_id] / (4.0f * M_PI);
+        unsigned j = alias_table[i].alias_id;
+        alias_table[i].pdf = importance[i] / (2.0f * M_PI * M_PI * sin_theta[i/size.x]);
+        alias_table[i].alias_pdf = importance[j] / (2.0f * M_PI * M_PI * sin_theta[j/size.x]);
     }
 
     vmaUnmapMemory(dev.allocator, readback_buffer.get_allocation());


### PR DESCRIPTION
A couple of small sampling fixes. The incorrect PDFs in envmap sampling caused poles to appear darker than they should, while the correlation in ggx_bsdf_sample could cause faint visible edges in extreme cases.