### PR TITLE
Fix scratch buffer alignment

### DIFF
--- a/src/aabb_scene.cc
+++ b/src/aabb_scene.cc
@@ -227,10 +227,11 @@ void aabb_scene::init_acceleration_structures(const char* timer_name)
             vk::BufferUsageFlagBits::eShaderDeviceAddress,
             vk::SharingMode::eExclusive
         );
-        as.scratch_buffer = create_buffer(
+        as.scratch_buffer = create_buffer_aligned(
             devices[i],
             scratch_info,
-            VMA_MEMORY_USAGE_GPU_ONLY
+            VMA_MEMORY_USAGE_GPU_ONLY,
+            devices[i].as_props.minAccelerationStructureScratchOffsetAlignment
         );
 
         as.blas_update_timer = timer(devices[i], timer_name);

--- a/src/mesh.cc
+++ b/src/mesh.cc
@@ -89,8 +89,9 @@ void build_acceleration_structure(
         vk::BufferUsageFlagBits::eShaderDeviceAddress,
         vk::SharingMode::eExclusive
     );
-    blas_scratch_buffer = create_buffer(
-        dev, scratch_info, VMA_MEMORY_USAGE_GPU_ONLY
+    blas_scratch_buffer = create_buffer_aligned(
+        dev, scratch_info, VMA_MEMORY_USAGE_GPU_ONLY,
+        dev.as_props.minAccelerationStructureScratchOffsetAlignment
     );
     blas_info.scratchData = blas_scratch_buffer.get_address();
 

--- a/src/scene.cc
+++ b/src/scene.cc
@@ -386,7 +386,10 @@ void scene::init_tlas(size_t i)
         vk::SharingMode::eExclusive
     );
 
-    as.scratch_buffer = create_buffer(devices[i], scratch_info, VMA_MEMORY_USAGE_GPU_ONLY);
+    as.scratch_buffer = create_buffer_aligned(
+        devices[i], scratch_info, VMA_MEMORY_USAGE_GPU_ONLY,
+        devices[i].as_props.minAccelerationStructureScratchOffsetAlignment
+    );
     tlas_info.scratchData = as.scratch_buffer.get_address();
 }
 


### PR DESCRIPTION
Hopefully this fixes #6. I find it odd how this didn't occur on other hardware, despite them apparently requiring even larger alignments (according to vulkan.gpuinfo.org). The PC I was testing on had 128, for example.