### PR TITLE
Fix sample counter in multi-GPU cases

### DIFF
--- a/shader/path_tracer.rgen
+++ b/shader/path_tracer.rgen
@@ -80,7 +80,7 @@ void main()
         uvec4(
             get_pixel_pos(),
             gl_LaunchIDEXT.z,
-            distribution.samples_accumulated + control.previous_samples
+            control.previous_samples
         )
     );
     vec2 cam_offset = vec2(0.0);

--- a/shader/sampling.glsl
+++ b/shader/sampling.glsl
@@ -9,6 +9,7 @@ layout(binding = SAMPLING_DATA_BINDING, set = 0) uniform sampling_data_buffer
 {
     // xyz: size, w: sampling_start_counter
     uvec4 size_start_counter;
+    uint rng_seed;
 } sampling_data;
 #endif
 
@@ -36,6 +37,7 @@ local_sampler init_local_sampler(uvec4 coord)
 {
     local_sampler ls;
     coord.w += sampling_data.size_start_counter.w;
+    coord.z += sampling_data.rng_seed;
 
 #if defined(USE_SOBOL_Z_ORDER_SAMPLING)
     ls.ss = init_sobol_z_sampler(coord);

--- a/src/renderer.hh
+++ b/src/renderer.hh
@@ -12,7 +12,7 @@ public:
     virtual ~renderer() = default;
 
     virtual void set_scene(scene* s) = 0;
-    virtual void reset_accumulation(bool reset_sample_counter = true) {(void)reset_sample_counter;};
+    virtual void reset_accumulation(bool reset_sample_counter = false) {(void)reset_sample_counter;};
     virtual void render() = 0;
     virtual void set_device_workloads(const std::vector<double>&) {}
 

--- a/src/renderer.hh
+++ b/src/renderer.hh
@@ -12,7 +12,7 @@ public:
     virtual ~renderer() = default;
 
     virtual void set_scene(scene* s) = 0;
-    virtual void reset_accumulation() {};
+    virtual void reset_accumulation(bool reset_sample_counter = true) {(void)reset_sample_counter;};
     virtual void render() = 0;
     virtual void set_device_workloads(const std::vector<double>&) {}
 

--- a/src/rt_renderer.cc
+++ b/src/rt_renderer.cc
@@ -100,12 +100,16 @@ void rt_renderer<Pipeline>::set_scene(scene* s)
 }
 
 template<typename Pipeline>
-void rt_renderer<Pipeline>::reset_accumulation()
+void rt_renderer<Pipeline>::reset_accumulation(bool reset_sample_counter)
 {
     for(size_t i = 0; i < per_device.size(); ++i)
     {
         if(per_device[i].ray_tracer)
+        {
             per_device[i].ray_tracer->reset_accumulated_samples();
+            if(reset_sample_counter)
+                per_device[i].ray_tracer->reset_sample_counter();
+        }
     }
     accumulated_frames = 0;
     if(stitch)

--- a/src/rt_renderer.hh
+++ b/src/rt_renderer.hh
@@ -45,7 +45,7 @@ public:
     ~rt_renderer();
 
     void set_scene(scene* s) override;
-    void reset_accumulation() override;
+    void reset_accumulation(bool reset_sample_counter = true) override;
     void render() override;
     void set_device_workloads(const std::vector<double>& ratios) override;
 

--- a/src/rt_stage.hh
+++ b/src/rt_stage.hh
@@ -63,6 +63,8 @@ public:
     void set_scene(scene* s);
     scene* get_scene();
 
+    void reset_sample_counter();
+
     void set_local_sampler_parameters(
         uvec3 target_size,
         uint32_t frame_counter_increment
@@ -93,6 +95,7 @@ private:
     gpu_buffer sampling_data;
     uvec3 sampling_target_size;
     uint32_t sampling_frame_counter_increment;
+    uint32_t sample_counter;
 };
 
 }

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -777,7 +777,14 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
         }
 
         if(camera_moved || !opt.accumulation)
-            rr->reset_accumulation(opt.accumulation);
+        {
+            // With this commented line, sample counter restarts whenever the
+            // camera moves. This makes the noise pattern look still when
+            // moving, which may be unwanted, but could provide lower noise
+            // with some samplers in the future.
+            //rr->reset_accumulation(opt.accumulation);
+            rr->reset_accumulation(false);
+        }
 
         if(sd.ply_stream && sd.ply_stream->refresh())
         {

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -777,7 +777,7 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
         }
 
         if(camera_moved || !opt.accumulation)
-            rr->reset_accumulation();
+            rr->reset_accumulation(opt.accumulation);
 
         if(sd.ply_stream && sd.ply_stream->refresh())
         {


### PR DESCRIPTION
The number of accumulated samples, needed for initializing samplers, was incorrect for non-primary GPUs in multi-GPU setups. This is slightly visible in multi-GPU cases when accumulation is enabled. This PR fixes that.