### PR TITLE
Add option to format timing in "Trace Event Format"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,6 +146,7 @@ add_library(tauray-core STATIC
   src/texture.cc
   src/timer.cc
   src/tonemap_stage.cc
+  src/tracing.cc
   src/transformable.cc
   src/vkm.cc
   src/whitted_stage.cc

--- a/src/headless.cc
+++ b/src/headless.cc
@@ -122,7 +122,7 @@ void headless::finish_image(
     device_data& d = get_display_device();
     vk::PipelineStageFlags wait_stage = vk::PipelineStageFlagBits::eTopOfPipe;
 
-    if(!display)
+    if(!display || opt.output_file_type == EMPTY)
     {
         // Eat the binary semaphore.
         d.graphics_queue.submit(

--- a/src/load_balancer.cc
+++ b/src/load_balancer.cc
@@ -14,7 +14,7 @@ void load_balancer::update(renderer& ren)
     double sum_speed = 0;
     for(size_t i = 0; i < workloads.size(); ++i)
     {
-        double time = ctx->get_timing(i, "path tracing");
+        double time = ctx->get_timing().get_duration(i, "path tracing");
         double speed = max(workloads[i] / time, 0.0);
         sum_speed += speed;
     }
@@ -23,7 +23,7 @@ void load_balancer::update(renderer& ren)
     {
         for(size_t i = 0; i < workloads.size(); ++i)
         {
-            double time = ctx->get_timing(i, "path tracing");
+            double time = ctx->get_timing().get_duration(i, "path tracing");
             double speed = workloads[i] / time;
             workloads[i] = mix(workloads[i], speed/sum_speed, 0.1);
         }

--- a/src/options.hh
+++ b/src/options.hh
@@ -408,6 +408,12 @@
         TR_STRUCT_OPT_FLOAT(sensor_size, 0.036f, 0.0f, FLT_MAX) \
         TR_STRUCT_OPT_INT(sides, 0, 3, INT_MAX) \
         TR_STRUCT_OPT_FLOAT(angle, 0, 0, 360) \
+    ) \
+    TR_ENUM_OPT(trace, tracing_record::trace_format, \
+        "Sets the performance trace output format.", \
+        tracing_record::SIMPLE, \
+        {"simple", tracing_record::SIMPLE}, \
+        {"trace-event-format", tracing_record::TRACE_EVENT_FORMAT} \
     )
 //==============================================================================
 // END OF OPTIONS

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -695,7 +695,7 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
                     camera_moved = true;
                 }
                 if(event.key.keysym.sym == SDLK_t && !opt.timing)
-                    ctx.print_timing();
+                    ctx.get_timing().print_last_trace(opt.trace);
                 if(event.key.keysym.sym == SDLK_0)
                 {
                     // Full camera reset, for when you get lost ;)
@@ -813,7 +813,7 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
                 lkg->recreate_swapchains();
             else break;
         }
-        if(opt.timing) ctx.print_timing();
+        if(opt.timing) ctx.get_timing().print_last_trace(opt.trace);
 
         throttle.step();
         lb.update(*rr);
@@ -922,7 +922,7 @@ void replay_viewer(context& ctx, scene_data& sd, options& opt)
             {
                 rr->reset_accumulation();
                 rr->render();
-                if(opt.timing) ctx.print_timing();
+                if(opt.timing) ctx.get_timing().print_last_trace(opt.trace);
             }
         }
         catch(vk::OutOfDateKHRError& e)
@@ -950,7 +950,7 @@ void replay_viewer(context& ctx, scene_data& sd, options& opt)
     }
 
     // Ensure everything is finished before going to destructors.
-    ctx.finish_print_timing();
+    ctx.get_timing().wait_all_frames(opt.timing, opt.trace);
 }
 
 void headless_server(context& ctx, scene_data& sd, options& opt)

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -11,7 +11,7 @@ timer::timer()
 timer::timer(device_data& dev, const std::string& name)
 : dev(&dev)
 {
-    timer_id = dev.ctx->register_timer(dev.index, name);
+    timer_id = dev.ctx->get_timing().register_timer(dev.index, name);
 }
 
 timer::timer(timer&& other)
@@ -22,12 +22,12 @@ timer::timer(timer&& other)
 
 timer::~timer()
 {
-    if(dev) dev->ctx->unregister_timer(dev->index, timer_id);
+    if(dev) dev->ctx->get_timing().unregister_timer(dev->index, timer_id);
 }
 
 timer& timer::operator=(timer&& other)
 {
-    if(dev) dev->ctx->unregister_timer(dev->index, timer_id);
+    if(dev) dev->ctx->get_timing().unregister_timer(dev->index, timer_id);
     dev = other.dev;
     timer_id = other.timer_id;
     other.dev = nullptr;
@@ -39,7 +39,7 @@ void timer::begin(
 ){
     if(timer_id < 0 || !dev) return;
     uint32_t query_id = timer_id * 2u;
-    vk::QueryPool pool = dev->ctx->get_timestamp_pool(dev->index, frame_index);
+    vk::QueryPool pool = dev->ctx->get_timing().get_timestamp_pool(dev->index, frame_index);
     cb.resetQueryPool(pool, query_id, 2);
     cb.writeTimestamp(stage, pool, query_id);
 }
@@ -49,7 +49,7 @@ void timer::end(
 ){
     if(timer_id < 0 || !dev) return;
     uint32_t query_id = timer_id * 2u;
-    vk::QueryPool pool = dev->ctx->get_timestamp_pool(dev->index, frame_index);
+    vk::QueryPool pool = dev->ctx->get_timing().get_timestamp_pool(dev->index, frame_index);
     cb.writeTimestamp(stage, pool, query_id+1);
 }
 

--- a/src/tracing.cc
+++ b/src/tracing.cc
@@ -1,0 +1,307 @@
+#include "tracing.hh"
+#include "context.hh"
+#include "json.hpp"
+#include <iostream>
+
+namespace tr
+{
+
+enum trace_format
+{
+    TAURAY,
+    TRACE_EVENT_FORMAT
+};
+
+tracing_record::tracing_record(context* ctx)
+: ctx(ctx), frame_counter(0), host_finished_frame_counter(0), device_finished_frame_counter(0)
+{
+}
+
+void tracing_record::init(unsigned max_timestamps)
+{
+    this->max_timestamps = max_timestamps;
+    if(max_timestamps)
+    {
+        auto& devices = ctx->get_devices();
+        timing_resources.resize(devices.size());
+        for(size_t i = 0; i < devices.size(); ++i)
+        {
+            timing_data& t = timing_resources[i];
+            t.timestamp_pools.resize(MAX_FRAMES_IN_FLIGHT);
+            for(size_t j = 0; j < MAX_FRAMES_IN_FLIGHT; ++j)
+                t.timestamp_pools[j] = vkm(
+                    devices[i],
+                    devices[i].dev.createQueryPool({
+                        {}, vk::QueryType::eTimestamp, max_timestamps * 2u
+                    })
+                );
+            for(unsigned j = 0; j < max_timestamps; ++j)
+                t.available_queries.insert(j);
+        }
+
+        host_reference_ns = std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::steady_clock::now().time_since_epoch()).count() * 1e9;
+        for(size_t i = 0; i < devices.size(); ++i)
+        {
+           vk::CalibratedTimestampInfoEXT info;
+           info.timeDomain = vk::TimeDomainEXT::eDevice;
+           timing_resources[i].device_reference_ns = double(devices[i].dev.getCalibratedTimestampEXT(info).first)*double(devices[i].props.limits.timestampPeriod);
+        }
+    }
+}
+
+void tracing_record::deinit()
+{
+    timing_resources.clear();
+}
+
+void tracing_record::begin_frame()
+{
+    finish_host_frame();
+
+    if(times.size() != 0 && times.front().frame_number + 1 < device_finished_frame_counter)
+        times.pop_front();
+
+    times.push_back({frame_counter, {}, {}});
+    frame_counter++;
+}
+
+void tracing_record::host_wait()
+{
+    if(times.size() == 0) return;
+    wait_start_time = std::chrono::steady_clock::now();
+    timing_result& res = times.back();
+    res.host_traces.push_back({
+        std::chrono::duration_cast<std::chrono::duration<double>>(frame_start_time.time_since_epoch()).count() * 1e9 - host_reference_ns,
+        std::chrono::duration_cast<std::chrono::duration<double>>(wait_start_time - frame_start_time).count() * 1e9,
+        "CPU working"
+    });
+}
+
+void tracing_record::device_finish_frame()
+{
+    if(max_timestamps == 0) return;
+
+    timing_result* res = nullptr;
+    for(auto it = times.begin(); it != times.end(); ++it)
+    {
+        if(it->frame_number == device_finished_frame_counter)
+            res = &*it;
+    }
+    if(!res) return;
+
+    uint32_t findex = res->frame_number%MAX_FRAMES_IN_FLIGHT;
+
+    const auto& devices = ctx->get_devices();
+    res->device_traces.resize(devices.size());
+    for(size_t i = 0; i < res->device_traces.size(); ++i)
+    {
+        timing_data& t = timing_resources[i];
+        std::vector<uint64_t> results(max_timestamps*2u);
+        (void)devices[i].dev.getQueryPoolResults(
+            t.timestamp_pools[findex],
+            0,
+            max_timestamps*2u,
+            results.size()*sizeof(uint64_t),
+            results.data(),
+            0,
+            vk::QueryResultFlagBits::e64
+        );
+        for(const auto& pair: t.reserved_queries)
+        {
+            res->device_traces[i].push_back(trace_event{
+                double(results[pair.first*2])*double(devices[i].props.limits.timestampPeriod) - t.device_reference_ns,
+                double(results[pair.first*2+1]-results[pair.first*2])*double(devices[i].props.limits.timestampPeriod),
+                pair.second
+            });
+        }
+        std::sort(
+            res->device_traces[i].begin(),
+            res->device_traces[i].end(),
+            [](const trace_event& a, const trace_event& b){
+                return a.start_ns < b.start_ns;
+            }
+        );
+    }
+
+    device_finished_frame_counter++;
+}
+
+void tracing_record::wait_all_frames(bool print_traces, trace_format format)
+{
+    if(max_timestamps == 0) return;
+    ctx->sync();
+    finish_host_frame();
+    while(device_finished_frame_counter < frame_counter)
+    {
+        device_finish_frame();
+        if(print_traces)
+            print_last_trace(format);
+    }
+}
+
+int tracing_record::register_timer(size_t device_index, const std::string& name)
+{
+    if(max_timestamps == 0) return -1;
+    timing_data& t = timing_resources[device_index];
+    if(t.available_queries.size() == 0)
+        throw std::runtime_error(
+            "Not enough timer queries in pool! Increase max_timestamps!"
+        );
+    auto it = t.available_queries.begin();
+    int ret = *it;
+    t.reserved_queries[ret] = name;
+    t.available_queries.erase(it);
+    return ret;
+}
+
+void tracing_record::unregister_timer(size_t device_index, int timer_id)
+{
+    if(max_timestamps == 0) return;
+    timing_data& t = timing_resources[device_index];
+    t.reserved_queries.erase(timer_id);
+    t.available_queries.insert(timer_id);
+}
+
+vk::QueryPool tracing_record::get_timestamp_pool(size_t device_index, uint32_t frame_index)
+{
+    if(max_timestamps == 0) return {};
+    return timing_resources[device_index].timestamp_pools[frame_index];
+}
+
+float tracing_record::get_duration(size_t device_index, const std::string& name) const
+{
+    const timing_result* res = find_latest_finished_frame();
+    if(!res) return 0.0f;
+    float total_time = 0.0f;
+    for(const trace_event& ti: res->device_traces[device_index])
+    {
+        if(ti.name.compare(0, name.length(), name) == 0)
+            total_time += ti.duration_ns;
+    }
+    return total_time;
+}
+
+void tracing_record::print_last_trace(trace_format format)
+{
+    const timing_result* res = find_latest_finished_frame();
+    if(!res) return;
+
+    switch(format)
+    {
+    default:
+    case SIMPLE:
+        print_simple_trace(*res);
+        break;
+    case TRACE_EVENT_FORMAT:
+        print_tef_trace(*res);
+        break;
+    }
+}
+
+void tracing_record::finish_host_frame()
+{
+    auto time_now = std::chrono::steady_clock::now();
+    if(frame_counter > host_finished_frame_counter)
+    {
+        timing_result& res = times.back();
+        host_finished_frame_counter++;
+
+        res.host_traces.push_back({
+            std::chrono::duration_cast<std::chrono::duration<double>>(wait_start_time.time_since_epoch()).count() * 1e9 - host_reference_ns,
+            std::chrono::duration_cast<std::chrono::duration<double>>(time_now - wait_start_time).count() * 1e9,
+            res.host_traces.size() == 0 ? "CPU working" : "CPU waiting"
+        });
+    }
+    frame_start_time = time_now;
+    wait_start_time = time_now;
+}
+
+const tracing_record::timing_result* tracing_record::find_latest_finished_frame() const
+{
+    for(auto it = times.rbegin(); it != times.rend(); ++it)
+    {
+        if(it->frame_number < host_finished_frame_counter && it->frame_number < device_finished_frame_counter)
+            return &*it;
+    }
+    return nullptr;
+}
+
+void tracing_record::print_simple_trace(const timing_result& res)
+{
+    std::cout << "FRAME " << res.frame_number << ":\n";
+    for(size_t i = 0; i < res.device_traces.size(); ++i)
+    {
+        const std::vector<trace_event>& times = res.device_traces[i];
+
+        std::cout << "\tDEVICE " << i << ": ";
+        if(times.size() == 0)
+            std::cout << "\n";
+        else
+        {
+            double delta_ns = times.back().start_ns + times.back().duration_ns - times.front().start_ns;
+            std::cout << delta_ns/1e6 << " ms\n";
+        }
+
+        for(const trace_event& t: times)
+        {
+            std::cout << "\t\t[" << t.name << "] " << t.duration_ns/1e6 << " ms"
+                << "\n";
+        }
+    }
+
+    std::cout << "\tHOST: ";
+    if(res.host_traces.size() == 0)
+        std::cout << "\n";
+    else
+    {
+        double delta_ns = res.host_traces.back().start_ns + res.host_traces.back().duration_ns - res.host_traces.front().start_ns;
+        std::cout << delta_ns/1e6 << " ms\n";
+    }
+    for(const trace_event& t: res.host_traces)
+    {
+        std::cout << "\t\t[" << t.name << "] " << t.duration_ns/1e6 << " ms"
+            << "\n";
+    }
+}
+
+void tracing_record::print_tef_trace(const timing_result& res)
+{
+    static bool first_call = true;
+    if(first_call)
+    {
+        std::cout << "[";
+        first_call = false;
+    }
+    for(const trace_event& t: res.host_traces)
+    {
+        nlohmann::json output = {
+            {"pid",0},
+            {"tid",0},
+            {"ts",int64_t(t.start_ns*1e-3)},
+            {"dur",int64_t(t.duration_ns*1e-3)},
+            {"ph", "X"},
+            {"name", t.name},
+            {"args", {"ms", t.duration_ns*1e-6}}
+        };
+        std::cout << output.dump(-1, '\t') << ",\n";
+    }
+    for(size_t i = 0; i < res.device_traces.size(); ++i)
+    {
+        for(const trace_event& t: res.device_traces[i])
+        {
+            nlohmann::json output = {
+                {"pid",1},
+                {"tid",i},
+                {"ts",int64_t(t.start_ns*1e-3)},
+                {"dur",int64_t(t.duration_ns*1e-3)},
+                {"ph", "X"},
+                {"name", t.name},
+                {"args", {"ms", t.duration_ns*1e-6}}
+            };
+            std::cout << output.dump(-1, '\t') << ",\n";
+        }
+    }
+}
+
+}
+

--- a/src/tracing.cc
+++ b/src/tracing.cc
@@ -281,7 +281,7 @@ void tracing_record::print_tef_trace(const timing_result& res)
             {"dur",int64_t(t.duration_ns*1e-3)},
             {"ph", "X"},
             {"name", t.name},
-            {"args", {"ms", t.duration_ns*1e-6}}
+            {"args", {"frame", res.frame_number}}
         };
         std::cout << output.dump(-1, '\t') << ",\n";
     }
@@ -296,7 +296,7 @@ void tracing_record::print_tef_trace(const timing_result& res)
                 {"dur",int64_t(t.duration_ns*1e-3)},
                 {"ph", "X"},
                 {"name", t.name},
-                {"args", {"ms", t.duration_ns*1e-6}}
+                {"args", {"frame", res.frame_number}}
             };
             std::cout << output.dump(-1, '\t') << ",\n";
         }

--- a/src/tracing.hh
+++ b/src/tracing.hh
@@ -1,0 +1,86 @@
+#ifndef TAURAY_TRACING_HH
+#define TAURAY_TRACING_HH
+
+#include "vkm.hh"
+#include <set>
+#include <map>
+#include <deque>
+#include <chrono>
+
+namespace tr
+{
+
+struct trace_event
+{
+    double start_ns;
+    double duration_ns;
+    std::string name;
+};
+
+class context;
+
+class tracing_record
+{
+public:
+    enum trace_format
+    {
+        SIMPLE,
+        TRACE_EVENT_FORMAT
+    };
+
+    tracing_record(context* ctx);
+    void init(unsigned max_timestamps);
+    void deinit();
+
+    void begin_frame();
+    void host_wait();
+    void device_finish_frame();
+    void wait_all_frames(bool print_traces, trace_format format = SIMPLE);
+
+    int register_timer(size_t device_index, const std::string& name);
+    void unregister_timer(size_t device_index, int timer_id);
+    vk::QueryPool get_timestamp_pool(size_t device_index, uint32_t frame_index);
+
+    float get_duration(size_t device_index, const std::string& name) const;
+    void print_last_trace(trace_format format = SIMPLE);
+
+private:
+    struct timing_result
+    {
+        uint32_t frame_number = 0;
+        std::vector<trace_event> host_traces;
+        std::vector<std::vector<trace_event>> device_traces;
+    };
+
+    void finish_host_frame();
+    const timing_result* find_latest_finished_frame() const;
+    void print_simple_trace(const timing_result& res);
+    void print_tef_trace(const timing_result& res);
+
+    context* ctx;
+    unsigned max_timestamps;
+    uint32_t frame_counter;
+    uint32_t host_finished_frame_counter;
+    uint32_t device_finished_frame_counter;
+    std::deque<timing_result> times;
+
+    struct timing_data
+    {
+        std::vector<vkm<vk::QueryPool>> timestamp_pools;
+
+        std::set<int> available_queries;
+        std::map<int, std::string> reserved_queries;
+
+        double device_reference_ns;
+    };
+    std::vector<timing_data> timing_resources;
+    std::chrono::steady_clock::time_point frame_start_time;
+    std::chrono::steady_clock::time_point wait_start_time;
+
+    double host_reference_ns;
+};
+
+}
+
+#endif
+


### PR DESCRIPTION
`--trace=trace-event-format` can now be used to change the timing output into the format expected by Chrome's about:tracing. This lets the user view timing info with a nifty GUI.

I also refactored parts of the timing infrastructure for this.