### PR TITLE
Add config file support & presets & CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Tauray has been tested on the Ubuntu 22.04 operating system. Building on Ubuntu
 1. Install dependencies: `sudo apt install build-essential cmake libsdl2-dev libglm-dev libczmq-dev libnng-dev libcbor-dev vulkan-tools libvulkan-dev vulkan-validationlayers libxcb-glx0-dev glslang-tools`
 2. `cmake -S . -B build`
 3. `cmake --build build`
-4. `build/tauray my_scene.glb`
+4. `build/tauray my_scene.glb --preset=accumulation`
 
 Building with Windows is also possible but not recommended. You can use the
 CMakeLists.txt with Visual Studio. A vcpkg.json is provided in this repository
@@ -70,7 +70,7 @@ supported on Windows.
 To launch a simple interactive path tracing session with the included test model:
 
 ```bash
-build/tauray test/test.glb
+build/tauray test/test.glb --preset=accumulation
 ```
 
 [See the user manual for more detailed usage documentation.](docs/tauray_user_manual.pdf)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Tauray has been tested on the Ubuntu 22.04 operating system. Building on Ubuntu
 1. Install dependencies: `sudo apt install build-essential cmake libsdl2-dev libglm-dev libczmq-dev libnng-dev libcbor-dev vulkan-tools libvulkan-dev vulkan-validationlayers libxcb-glx0-dev glslang-tools`
 2. `cmake -S . -B build`
 3. `cmake --build build`
-4. `build/tauray my_scene.glb --preset=accumulation`
+4. `build/tauray my_scene.glb`
 
 Building with Windows is also possible but not recommended. You can use the
 CMakeLists.txt with Visual Studio. A vcpkg.json is provided in this repository
@@ -88,7 +88,7 @@ and **disable validation**:
 You may also want to set `--force-double-sided` for better performance if your
 scene does not require single-sided surfaces. Also, remember to set
 `--max-ray-depth` appropriately for the type of benchmark, the default is quite
-high.
+high. It sets the number of bounces.
 
 By default, Tauray will use all GPUs with support for the required extensions.
 If you wish to use a specific GPU on a multi-GPU system, use `--devices=0` (or

--- a/data/presets/accumulation.cfg
+++ b/data/presets/accumulation.cfg
@@ -1,0 +1,10 @@
+# Don't want validation layers ruining our performance.
+validation off
+film blackman-harris
+force-double-sided on
+max-ray-depth 5
+accumulation on
+renderer path-tracer
+sampler sobol-z3
+samples-per-pixel 1
+regularization 0.5

--- a/data/presets/ddish-gi.cfg
+++ b/data/presets/ddish-gi.cfg
@@ -1,0 +1,22 @@
+# This preset has the recommended settings for DDISH-GI. Note that these
+# settings are pretty slow, so not suitable for LF displays. You should set
+# pcf & pcss to zero for those, drop the shadow map resolution a bit, and
+# set samples-per-pixel to 1.
+validation off
+renderer dshgi
+dshgi-temporal-ratio 0.01
+max-ray-depth 4
+sampler uniform-random
+regularization 1.0
+indirect-clamping 10
+samples-per-probe 512
+shadow-map-resolution 4096
+pcf 64
+pcss 32
+film box
+film-radius 0.5
+shadow-map-bias 0.02
+# Here, this means MSAA.
+samples-per-pixel 8
+
+tonemap filmic

--- a/data/presets/denoised.cfg
+++ b/data/presets/denoised.cfg
@@ -1,0 +1,19 @@
+# This preset is for denoised real-time path tracing.
+validation off
+
+renderer path-tracer
+denoiser svgf
+taa 8
+
+force-double-sided on
+
+max-ray-depth 4
+
+# Blue noise-ish sampler so that it's easier to denoise. sobol-z3 could be
+# better for when spp > 1.
+sampler sobol-z2
+samples-per-pixel 1
+
+# Eliminate fireflies
+regularization 1
+indirect-clamping 20

--- a/data/presets/quality.cfg
+++ b/data/presets/quality.cfg
@@ -1,0 +1,15 @@
+# This preset creates a "high-quality" render, if you just want pretty offline
+# images pretty quickly.
+validation off
+film blackman-harris
+max-ray-depth 4
+samples-per-pixel 4096
+force-double-sided on
+sampler uniform-random
+regularization 0.5
+indirect-clamping 100
+renderer path-tracer
+
+tonemap filmic
+filetype png
+headless quality

--- a/data/presets/reference.cfg
+++ b/data/presets/reference.cfg
@@ -1,0 +1,11 @@
+# This is a proper reference render; not the fastest setup for this SPP. See
+# fast-reference for better quality and speed options.
+film blackman-harris
+max-ray-depth 8
+samples-per-pixel 16384
+sampler uniform-random
+renderer path-tracer
+
+tonemap linear
+filetype exr
+headless reference

--- a/data/presets/reference.cfg
+++ b/data/presets/reference.cfg
@@ -1,5 +1,5 @@
 # This is a proper reference render; not the fastest setup for this SPP. See
-# fast-reference for better quality and speed options.
+# quality preset for better quality and speed options.
 film blackman-harris
 max-ray-depth 8
 samples-per-pixel 16384

--- a/src/compute_pipeline.cc
+++ b/src/compute_pipeline.cc
@@ -37,7 +37,7 @@ compute_pipeline::compute_pipeline(device_data& dev, const params& p)
         pipeline_layout, {}, 0
     );
 
-    pipeline = vkm(dev, dev.dev.createComputePipeline({}, pipeline_info).value);
+    pipeline = vkm(dev, dev.dev.createComputePipeline(dev.pp_cache, pipeline_info).value);
 }
 
 }

--- a/src/context.cc
+++ b/src/context.cc
@@ -636,6 +636,8 @@ void context::init_devices()
             dev_data.transfer_pool = dev_data.dev.createCommandPool(
                 {{}, dev_data.transfer_family_index}
             );
+            dev_data.pp_cache = dev_data.dev.createPipelineCache({
+            });
 
             VmaAllocatorCreateInfo allocator_info = {};
             allocator_info.physicalDevice = pdev;
@@ -657,6 +659,7 @@ void context::deinit_devices()
     sync();
     for(device_data& dev_data: devices)
     {
+        dev_data.dev.destroyPipelineCache(dev_data.pp_cache);
         dev_data.dev.destroyCommandPool(dev_data.graphics_pool);
         dev_data.dev.destroyCommandPool(dev_data.compute_pool);
         if(dev_data.has_present)

--- a/src/context.hh
+++ b/src/context.hh
@@ -49,6 +49,7 @@ struct device_data
     vk::CommandPool compute_pool;
     vk::CommandPool present_pool;
     vk::CommandPool transfer_pool;
+    vk::PipelineCache pp_cache;
     VmaAllocator allocator;
 };
 

--- a/src/gfx_pipeline.cc
+++ b/src/gfx_pipeline.cc
@@ -336,7 +336,7 @@ void gfx_pipeline::init_pipeline()
             -1
         );
 
-        pipeline = vkm(*dev, dev->dev.createGraphicsPipeline({}, pipeline_info).value);
+        pipeline = vkm(*dev, dev->dev.createGraphicsPipeline(dev->pp_cache, pipeline_info).value);
 
         init_framebuffers();
     }
@@ -354,7 +354,7 @@ void gfx_pipeline::init_pipeline()
             -1
         );
 
-        pipeline = vkm(*dev, dev->dev.createRayTracingPipelineKHR({}, {}, pipeline_info).value);
+        pipeline = vkm(*dev, dev->dev.createRayTracingPipelineKHR({}, dev->pp_cache, pipeline_info).value);
 
         // Create shader binding table
         uint32_t group_handle_size = align_up_to(

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,6 +3,8 @@
 
 int main(int, char** argv) try
 {
+    std::ios_base::sync_with_stdio(false);
+
     tr::options opt;
     tr::parse_command_line_options(argv, opt);
     std::unique_ptr<tr::context> ctx(tr::create_context(opt));

--- a/src/main.cc
+++ b/src/main.cc
@@ -3,7 +3,8 @@
 
 int main(int, char** argv) try
 {
-    tr::options opt = tr::parse_options(argv);
+    tr::options opt;
+    tr::parse_command_line_options(argv, opt);
     std::unique_ptr<tr::context> ctx(tr::create_context(opt));
 
     tr::scene_data sd = tr::load_scenes(*ctx, opt);

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -570,6 +570,25 @@ std::string load_text_file(const std::string& path)
     return ret;
 }
 
+bool nonblock_getline(std::string& line)
+{
+    static std::stringstream reading;
+    line.clear();
+
+    char c;
+    while(std::cin.readsome(&c, 1))
+    {
+        if(c == '\n')
+        {
+            line = reading.str();
+            reading.str("");
+            return true;
+        }
+        reading << c;
+    }
+    return false;
+}
+
 std::string to_uppercase(const std::string& str)
 {
     std::string ret(str);

--- a/src/misc.hh
+++ b/src/misc.hh
@@ -103,6 +103,7 @@ vk::SampleCountFlagBits get_max_available_sample_count(context& ctx);
 
 std::string get_resource_path(const std::string& path);
 std::string load_text_file(const std::string& path);
+bool nonblock_getline(std::string& line);
 
 template<typename T>
 void sorted_insert(

--- a/src/options.cc
+++ b/src/options.cc
@@ -418,8 +418,9 @@ void parse_command_line_options(char** argv, options& opt)
 #undef TR_STRUCT_OPT
 }
 
-void parse_config_options(const char* config_str, options& opt)
+bool parse_config_options(const char* config_str, options& opt)
 {
+    bool got_any = false;
     while(*config_str != 0)
     {
         std::string identifier;
@@ -542,6 +543,21 @@ void parse_config_options(const char* config_str, options& opt)
 #undef TR_STRUCT_OPT
         else throw option_parse_error(
             "Unknown option " + std::string(arg));
+        got_any = true;
+    }
+    return got_any;
+}
+
+bool parse_command(const char* config_str, options& opt)
+{
+    try
+    {
+        return parse_config_options(config_str, opt);
+    }
+    catch(const option_parse_error& err)
+    {
+        std::cerr << err.what() << std::endl;
+        return false;
     }
 }
 

--- a/src/options.cc
+++ b/src/options.cc
@@ -1,4 +1,5 @@
 #include "options.hh"
+#include "misc.hh"
 #include <cstring>
 #include <cstdlib>
 #include <iostream>
@@ -35,6 +36,50 @@ bool prefix(const char*& arg, const std::string& prefix)
 bool cmp(const char*& arg, const std::string& prefix)
 {
     return arg == prefix;
+}
+
+bool parse_identifier(const char*& arg, std::string& name)
+{
+    // Skip whitespace
+    arg += strspn(arg, " \t\r\n");
+    size_t len = strcspn(arg, " \t\r\n=");
+    if(len == 0)
+        return false;
+    name = std::string(arg, len);
+    arg += len;
+    arg += strspn(arg, " \t\r\n=");
+    return true;
+}
+
+void parse_param(const std::string& name, const char*& arg, std::string& param)
+{
+    // Skip leading whitespace
+    arg += strspn(arg, " \t\r\n");
+    // If quote
+    if(*arg == '"' || *arg == '\'')
+    {
+        char sep = *arg;
+        arg++;
+        const char* end = strchr(arg, sep);
+        if(end == nullptr)
+            throw option_parse_error(name + " has quoted parameter with missing unquote!");
+        param = std::string(arg, end-arg);
+        arg = end+1;
+        arg += strspn(arg, " \t\r\n");
+    }
+    else
+    { // Read until newline, strip back
+        const char* end = strchr(arg, '\n');
+        if(end == nullptr) end = arg+strlen(arg);
+
+        param = std::string(arg, end-arg);
+        arg = end;
+        arg += strspn(arg, " \t\r\n");
+
+        size_t strip_len = param.find_last_not_of(" \t\r\n");
+        if(strip_len != std::string::npos)
+            param.erase(strip_len+1);
+    }
 }
 
 int parse_int(const std::string& name, const char*& arg, int min, int max, char end = '\0')
@@ -153,9 +198,8 @@ std::string build_option_string(
 namespace tr
 {
 
-options parse_options(char** argv)
+void parse_command_line_options(char** argv, options& opt)
 {
-    options opt;
     argv++; // Skip name
     bool skip_flags = false;
     opt.film_radius = -1.0f;
@@ -169,6 +213,15 @@ options parse_options(char** argv)
             {
                 if(*arg == 0) skip_flags = true;
                 else if(cmp(arg, "help")) throw option_parse_error("");
+                else if(prefix(arg, "config="))
+                    parse_config_options(load_text_file(arg).c_str(), opt);
+                else if(prefix(arg, "preset="))
+                {
+                    parse_config_options(
+                        load_text_file(get_resource_path(std::string("data/presets/")+arg+".cfg")).c_str(),
+                        opt
+                    );
+                }
 #define TR_BOOL_OPT(name, description, default) \
                 else if(cmp(arg, DASHIFY(name))) opt.name = true; \
                 else if(prefix(arg, DASHIFY(name)+"=")) \
@@ -308,7 +361,7 @@ options parse_options(char** argv)
     // The frame client has no required options and is mostly a separate program
     // anyway, so let's just skip the pointless option validation.
     if(opt.display == options::display_type::FRAME_CLIENT)
-        return opt;
+        return;
 
     if(opt.scene_paths.size() == 0)
         throw option_parse_error("No scene specified!");
@@ -351,8 +404,6 @@ options parse_options(char** argv)
         else if(opt.film == film::BLACKMAN_HARRIS)
             opt.film_radius = 1.0f;
     }
-
-    return opt;
 #undef TR_BOOL_OPT
 #undef TR_BOOL_SOPT
 #undef TR_INT_OPT
@@ -367,6 +418,133 @@ options parse_options(char** argv)
 #undef TR_STRUCT_OPT
 }
 
+void parse_config_options(const char* config_str, options& opt)
+{
+    while(*config_str != 0)
+    {
+        std::string identifier;
+        if(!parse_identifier(config_str, identifier))
+            continue;
+
+        if(identifier[0] == '#')
+        {
+            const char* end = strchr(config_str, '\n');
+            if(end == nullptr) end = config_str+strlen(config_str);
+            config_str = end;
+            continue;
+        }
+
+        std::string param;
+
+        parse_param(identifier, config_str, param);
+
+        const char* arg = param.c_str();
+
+        if(identifier == "config")
+            parse_config_options(load_text_file(param).c_str(), opt);
+        else if(identifier == "preset")
+        {
+            parse_config_options(
+                load_text_file(get_resource_path("data/presets/"+param+".cfg")).c_str(),
+                opt
+            );
+        }
+#define TR_BOOL_OPT(name, description, default) \
+        else if(identifier == DASHIFY(name)) \
+            opt.name = parse_toggle(DASHIFY(name), arg);
+#define TR_BOOL_SOPT(name, shorthand, description) \
+        TR_BOOL_OPT(name, description, false)
+#define TR_INT_OPT(name, description, default, min, max) \
+        else if(identifier == DASHIFY(name)) \
+            opt.name = parse_int(DASHIFY(name), arg, min, max);
+#define TR_INT_SOPT(name, shorthand, description, default, min, max) \
+        TR_INT_OPT(name, description, default, min, max)
+#define TR_FLOAT_OPT(name, description, default, min, max) \
+        else if(identifier == DASHIFY(name)) \
+            opt.name = parse_float(DASHIFY(name), arg, min, max);
+#define TR_STRING_OPT(name, description, default) \
+        else if(identifier == DASHIFY(name)) \
+            opt.name = arg;
+#define TR_FLAG_STRING_OPT(name, description, default) \
+        else if(identifier == DASHIFY(name)) \
+        {\
+            opt.name##_flag = true; \
+            opt.name = arg; \
+        }
+#define TR_VEC3_OPT(name, description, default, min, max) \
+        else if(identifier == DASHIFY(name)) \
+        {\
+            opt.name.x = parse_float(DASHIFY(name)+".x", arg, min.x, max.x, ','); \
+            if(*arg == ',') arg++; \
+            opt.name.y = parse_float(DASHIFY(name)+".y", arg, min.y, max.y, ','); \
+            if(*arg == ',') arg++; \
+            opt.name.z = parse_float(DASHIFY(name)+".z", arg, min.z, max.z); \
+        }
+#define TR_ENUM_OPT(name, type, description, default, ...) \
+        else if(identifier == DASHIFY(name)) \
+            enum_str(DASHIFY(name), opt.name, arg, { __VA_ARGS__ });
+#define TR_SETINT_OPT(name, description) \
+        else if(identifier == DASHIFY(name)) \
+        {\
+            while(true) \
+            {\
+                opt.name.insert(parse_int(DASHIFY(name), arg, INT_MIN, INT_MAX, ','));\
+                if(*arg != ',') break;\
+                arg++; \
+            }\
+        }
+#define TR_VECFLOAT_OPT(name, description) \
+        else if(identifier == DASHIFY(name)) \
+        {\
+            while(true) \
+            {\
+                opt.name.push_back(parse_float(DASHIFY(name), arg, -FLT_MAX, FLT_MAX, ','));\
+                if(*arg != ',') break;\
+                arg++; \
+            }\
+        }
+#define TR_STRUCT_OPT_INT(name, default, min, max) \
+        if(*arg != '\0') { \
+            s.name = parse_int(name_prefix+DASHIFY(name), arg, min, max, ','); \
+            if(*arg == ',') arg++; \
+        }
+#define TR_STRUCT_OPT_FLOAT(name, default, min, max) \
+        if(*arg != '\0') { \
+            s.name = parse_float(name_prefix+DASHIFY(name), arg, min, max, ','); \
+            if(*arg == ',') arg++; \
+        }
+#define TR_STRUCT_OPT(name, description, ...)\
+        else if(identifier == DASHIFY(name)) \
+        {\
+            std::string name_prefix = DASHIFY(name)+"."; \
+            auto& s = opt.name; \
+            __VA_ARGS__ \
+            if(*arg != '\0') \
+                throw option_parse_error( \
+                    "Unexpected extra value in struct: " +  \
+                    std::string(arg) \
+                ); \
+        }
+        TR_OPTIONS
+#undef TR_BOOL_OPT
+#undef TR_BOOL_SOPT
+#undef TR_INT_OPT
+#undef TR_INT_SOPT
+#undef TR_FLOAT_OPT
+#undef TR_STRING_OPT
+#undef TR_FLAG_STRING_OPT
+#undef TR_VEC3_OPT
+#undef TR_ENUM_OPT
+#undef TR_SETINT_OPT
+#undef TR_VECFLOAT_OPT
+#undef TR_STRUCT_OPT_INT
+#undef TR_STRUCT_OPT_FLOAT
+#undef TR_STRUCT_OPT
+        else throw option_parse_error(
+            "Unknown option " + std::string(arg));
+    }
+}
+
 void print_help(const char* program_name)
 {
     std::cout << "Usage: " << program_name << " [options] scene" << R"(
@@ -377,6 +555,10 @@ object described in the file.
 Options:
   --help
     Show this information.
+  --config=<string>
+    Load the given config file.
+  --preset=<reference|quality|accumulation|denoised|ddish-gi>
+    Load the given preset file (config file that is shipped with Tauray).
 )";
     std::map<std::string, std::string> short_option_strings;
     std::map<std::string, std::string> long_option_strings;

--- a/src/options.hh
+++ b/src/options.hh
@@ -531,7 +531,8 @@ struct options
 #undef TR_STRUCT_OPT_FLOAT
 };
 
-options parse_options(char** argv);
+void parse_command_line_options(char** argv, options& opt);
+void parse_config_options(const char* config_str, options& opt);
 void print_help(const char* program_name);
 
 }

--- a/src/options.hh
+++ b/src/options.hh
@@ -495,6 +495,7 @@ struct options
 
     using projection_option_type = std::optional<tr::camera::projection_type>;
 
+    bool running = true;
     std::vector<std::string> scene_paths;
 
 #define TR_BOOL_OPT(name, description, default) bool name = default;
@@ -534,6 +535,7 @@ struct options
 void parse_command_line_options(char** argv, options& opt);
 bool parse_config_options(const char* config_str, options& opt);
 bool parse_command(const char* config_str, options& opt);
+void print_command_help(const std::string& command);
 void print_help(const char* program_name);
 
 }

--- a/src/options.hh
+++ b/src/options.hh
@@ -532,7 +532,8 @@ struct options
 };
 
 void parse_command_line_options(char** argv, options& opt);
-void parse_config_options(const char* config_str, options& opt);
+bool parse_config_options(const char* config_str, options& opt);
+bool parse_command(const char* config_str, options& opt);
 void print_help(const char* program_name);
 
 }

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -66,6 +66,50 @@ struct throttler
     std::chrono::high_resolution_clock::time_point time;
 };
 
+void set_camera_params(const options& opt, scene_data& s)
+{
+    if(auto proj = opt.force_projection)
+    {
+        switch(*proj)
+        {
+        case camera::PERSPECTIVE:
+            s.s->get_camera()->perspective(90.0f, 1.0f, 0.1f, 100.0f);
+            break;
+        case camera::ORTHOGRAPHIC:
+            s.s->get_camera()->ortho(
+                -1.0f, 1.0f, -1.0f, 1.0f, 0.0f, 100.0f
+            );
+            break;
+        case camera::EQUIRECTANGULAR:
+            s.s->get_camera()->equirectangular(360, 180);
+            break;
+        default:
+            break;
+        }
+    }
+
+    s.s->get_camera()->set_aspect(
+        opt.aspect_ratio > 0 ?
+            opt.aspect_ratio : opt.width/(float)opt.height
+    );
+    if(opt.fov)
+        s.s->get_camera()->set_fov(opt.fov);
+
+    if(opt.camera_clip_range.near > 0)
+        s.s->get_camera()->set_near(opt.camera_clip_range.near);
+    if(opt.camera_clip_range.far > 0)
+        s.s->get_camera()->set_far(opt.camera_clip_range.far);
+
+    if(opt.depth_of_field.f_stop != 0)
+        s.s->get_camera()->set_focus(
+            opt.depth_of_field.f_stop,
+            opt.depth_of_field.distance,
+            opt.depth_of_field.sides,
+            opt.depth_of_field.angle,
+            opt.depth_of_field.sensor_size
+        );
+}
+
 scene_data load_scenes(context& ctx, const options& opt)
 {
     // The frame client does not need scene data :D
@@ -201,46 +245,7 @@ scene_data load_scenes(context& ctx, const options& opt)
     }
     else
     {
-        if(auto proj = opt.force_projection)
-        {
-            switch(*proj)
-            {
-            case camera::PERSPECTIVE:
-                s.s->get_camera()->perspective(90.0f, 1.0f, 0.1f, 100.0f);
-                break;
-            case camera::ORTHOGRAPHIC:
-                s.s->get_camera()->ortho(
-                    -1.0f, 1.0f, -1.0f, 1.0f, 0.0f, 100.0f
-                );
-                break;
-            case camera::EQUIRECTANGULAR:
-                s.s->get_camera()->equirectangular(360, 180);
-                break;
-            default:
-                break;
-            }
-        }
-
-        s.s->get_camera()->set_aspect(
-            opt.aspect_ratio > 0 ?
-                opt.aspect_ratio : opt.width/(float)opt.height
-        );
-        if(opt.fov)
-            s.s->get_camera()->set_fov(opt.fov);
-
-        if(opt.camera_clip_range.near > 0)
-            s.s->get_camera()->set_near(opt.camera_clip_range.near);
-        if(opt.camera_clip_range.far > 0)
-            s.s->get_camera()->set_far(opt.camera_clip_range.far);
-
-        if(opt.depth_of_field.f_stop != 0)
-            s.s->get_camera()->set_focus(
-                opt.depth_of_field.f_stop,
-                opt.depth_of_field.distance,
-                opt.depth_of_field.sides,
-                opt.depth_of_field.angle,
-                opt.depth_of_field.sensor_size
-            );
+        set_camera_params(opt, s);
     }
 
     if(opt.animation_flag)
@@ -614,7 +619,6 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
 
     std::unique_ptr<renderer> rr;
 
-    bool running = true;
     float speed = 1.0f;
     vec3 euler = cam.get_orientation_euler();
     float pitch = euler.x;
@@ -651,13 +655,14 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
 
     ivec3 camera_movement = ivec3(0);
     std::string command_line;
-    while(running)
+    while(opt.running)
     {
         camera_moved = false;
         if(nonblock_getline(command_line))
         {
             if(parse_command(command_line.c_str(), opt))
             {
+                set_camera_params(opt, sd);
                 recreate_renderer = true;
                 camera_moved = true;
             }
@@ -689,13 +694,13 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
         while(SDL_PollEvent(&event)) switch(event.type)
         {
         case SDL_QUIT:
-            running = false;
+            opt.running = false;
             break;
         case SDL_KEYDOWN:
         case SDL_KEYUP:
             if(event.type == SDL_KEYDOWN)
             {
-                if(event.key.keysym.sym == SDLK_ESCAPE) running = false;
+                if(event.key.keysym.sym == SDLK_ESCAPE) opt.running = false;
                 if(event.key.keysym.sym == SDLK_RETURN) paused = !paused;
                 if(event.key.keysym.sym == SDLK_PAGEUP)
                 {
@@ -973,13 +978,11 @@ void headless_server(context& ctx, scene_data& sd, options& opt)
     rr->set_scene(&s);
     ctx.set_displaying(true);
 
-    bool running = true;
-
     throttler throttle(opt.throttle);
     std::chrono::steady_clock::time_point start =
         std::chrono::steady_clock::now();
     float delta = 0.0f;
-    while(running)
+    while(opt.running)
     {
         if(ctx.init_frame())
             break;

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -650,13 +650,26 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
     bool camera_moved = false;
 
     ivec3 camera_movement = ivec3(0);
+    std::string command_line;
     while(running)
     {
         camera_moved = false;
+        if(nonblock_getline(command_line))
+        {
+            if(parse_command(command_line.c_str(), opt))
+            {
+                recreate_renderer = true;
+                camera_moved = true;
+            }
+        }
+
         if(recreate_renderer)
         {
             try
             {
+                s.set_shadow_map_renderer(nullptr);
+                s.set_sh_grid_textures(nullptr);
+                s.set_camera_jitter(get_camera_jitter_sequence(opt.taa.sequence_length, ctx.get_size()));
                 rr.reset(create_renderer(ctx, opt, s));
                 rr->set_scene(&s);
                 ctx.set_displaying(false);


### PR DESCRIPTION
Adds support for config files and adds some presets. Previously, options could only be set as command line parameters. Now, you can save them in configuration files, and load them with `--config=path-to-config-file.cfg`. Presets are implemented as just config files that are shipped with the program.

There's five presets for now.

1. `--preset=accumulation`: Accumulating real-time path tracer
2. `--preset=ddish-gi`: High-quality settings for real-time locally calculated DDISH-GI
3. `--preset=denoised`: Real-time path tracer with denoiser
4. `--preset=quality`: High-quality offline PNG renders for showing off
5. `--preset=reference`: Unbiased (no formal guarantees though ;)) reference path tracer mode, with linear EXR output