### PR TITLE
Use BSDF PDF for path regularization

### DIFF
--- a/data/presets/accumulation.cfg
+++ b/data/presets/accumulation.cfg
@@ -7,4 +7,4 @@ accumulation on
 renderer path-tracer
 sampler sobol-z3
 samples-per-pixel 1
-regularization 0.5
+regularization 0.2

--- a/data/presets/denoised.cfg
+++ b/data/presets/denoised.cfg
@@ -15,5 +15,4 @@ sampler sobol-z2
 samples-per-pixel 1
 
 # Eliminate fireflies
-regularization 1
-indirect-clamping 20
+regularization 0.5

--- a/data/presets/quality.cfg
+++ b/data/presets/quality.cfg
@@ -6,8 +6,7 @@ max-ray-depth 4
 samples-per-pixel 4096
 force-double-sided on
 sampler uniform-random
-regularization 0.5
-indirect-clamping 100
+regularization 0.1
 renderer path-tracer
 
 tonemap filmic

--- a/shader/path_tracer.glsl
+++ b/shader/path_tracer.glsl
@@ -498,9 +498,11 @@ void evaluate_ray(
 
 #ifdef PATH_SPACE_REGULARIZATION
         // Regularization strategy inspired by "Optimised Path Space Regularisation", 2021 Weier et al.
-        float original_roughness = mat.roughness;
+        // I'm using the BSDF PDF instead of roughness, which seems to be more
+        // effective at reducing fireflies.
+        if(bsdf_pdf != 0.0f)
+            regularization *= max(1 - control.regularization_gamma / pow(bsdf_pdf, 0.25f), 0.0f);
         mat.roughness = 1.0f - ((1.0f - mat.roughness) * regularization);
-        regularization *= max(1 - control.regularization_gamma * original_roughness, 0.0f);
 #endif
 
         mat3 tbn = create_tangent_space(v.mapped_normal);


### PR DESCRIPTION
This quick hack seems to be pretty good at removing all fireflies! It makes our path space regularization good enough that indirect-clamping is typically pointless. Basically, just using the BSDF PDF instead of roughness alone allows path regularization to work well on dielectrics with low roughness, which were an issue before.