### PR TITLE
Acceleration structure API usage improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(tauray-core STATIC
   external/tinyply.cc
   external/vk_mem_alloc.cc
   src/aabb_scene.cc
+  src/acceleration_structure.cc
   src/animation.cc
   src/atlas.cc
   src/basic_pipeline.cc

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Tauray
 
 |![Sponza and lots of teapots rendered in Tauray.](docs/images/teapot_sponza.png)                                                                          |
 |----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| The famous "Sponza" scene with teapots. 1920x1080 image (4096 spp, 4 bounces), rendered with Tauray in 18 seconds on a dual-GPU setup with RTX 3090 and RTX 2080 Ti. |
+| The famous "Sponza" scene with teapots. 1920x1080 image (4096 spp, 4 bounces), rendered with Tauray in 15 seconds on a dual-GPU setup with RTX 3090 and RTX 2080 Ti. |
 
 Tauray is a real-time rendering framework, with a focus on distributed computing, scalability,
 portability and low latency. It uses C++17 and Vulkan, primarily relying on the `VK_KHR_ray_tracing`

--- a/shader/extract_tri_lights.comp
+++ b/shader/extract_tri_lights.comp
@@ -30,13 +30,13 @@ void main()
         light.emission_factor = o.mat.emission_factor_double_sided.rgb;
 
         ivec3 i = ivec3(
-            indices[nonuniformEXT(o.mesh_id)].i[3*input_index+0],
-            indices[nonuniformEXT(o.mesh_id)].i[3*input_index+1],
-            indices[nonuniformEXT(o.mesh_id)].i[3*input_index+2]
+            indices[nonuniformEXT(control.instance_id)].i[3*input_index+0],
+            indices[nonuniformEXT(control.instance_id)].i[3*input_index+1],
+            indices[nonuniformEXT(control.instance_id)].i[3*input_index+2]
         );
-        vertex v0 = vertices[nonuniformEXT(o.mesh_id)].v[i.x];
-        vertex v1 = vertices[nonuniformEXT(o.mesh_id)].v[i.y];
-        vertex v2 = vertices[nonuniformEXT(o.mesh_id)].v[i.z];
+        vertex v0 = vertices[nonuniformEXT(control.instance_id)].v[i.x];
+        vertex v1 = vertices[nonuniformEXT(control.instance_id)].v[i.y];
+        vertex v2 = vertices[nonuniformEXT(control.instance_id)].v[i.z];
         light.pos[0] = (o.model * vec4(v0.pos, 1)).xyz;
         light.pos[1] = (o.model * vec4(v1.pos, 1)).xyz;
         light.pos[2] = (o.model * vec4(v2.pos, 1)).xyz;

--- a/shader/extract_tri_lights.comp
+++ b/shader/extract_tri_lights.comp
@@ -37,9 +37,15 @@ void main()
         vertex v0 = vertices[nonuniformEXT(control.instance_id)].v[i.x];
         vertex v1 = vertices[nonuniformEXT(control.instance_id)].v[i.y];
         vertex v2 = vertices[nonuniformEXT(control.instance_id)].v[i.z];
+#ifdef PRE_TRANSFORMED_VERTICES
+        light.pos[0] = v0.pos;
+        light.pos[1] = v1.pos;
+        light.pos[2] = v2.pos;
+#else
         light.pos[0] = (o.model * vec4(v0.pos, 1)).xyz;
         light.pos[1] = (o.model * vec4(v1.pos, 1)).xyz;
         light.pos[2] = (o.model * vec4(v2.pos, 1)).xyz;
+#endif
         light.uv[0] = v0.uv;
         light.uv[1] = v1.uv;
         light.uv[2] = v2.uv;

--- a/shader/path_tracer.rahit
+++ b/shader/path_tracer.rahit
@@ -18,10 +18,10 @@ void main()
 {
     vec3 view = gl_WorldRayDirectionEXT;
     vec2 uv;
-    bool back_facing;
-    get_interpolated_vertex_light(view, attribs, gl_InstanceID, gl_PrimitiveID, uv, back_facing);
+    int instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
+    get_interpolated_vertex_light(view, attribs, instance_id, gl_PrimitiveID, uv);
     float alpha_cutoff = generate_single_uniform_random(payload.random_seed);
-    if(is_material_skippable(gl_InstanceID, uv, back_facing, alpha_cutoff))
+    if(is_material_skippable(instance_id, uv, alpha_cutoff))
         ignoreIntersectionEXT;
 }
 

--- a/shader/path_tracer.rchit
+++ b/shader/path_tracer.rchit
@@ -10,7 +10,7 @@ layout(location = 0) rayPayloadInEXT hit_payload payload;
 
 void main()
 {
-    payload.instance_id = gl_InstanceID;
+    payload.instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
     payload.primitive_id = gl_PrimitiveID;
     payload.barycentrics = attribs;
 }

--- a/shader/path_tracer_shadow.rahit
+++ b/shader/path_tracer_shadow.rahit
@@ -19,25 +19,17 @@ layout(location = 1) rayPayloadInEXT float shadow_visibility;
 void main()
 {
     vec3 view = gl_WorldRayDirectionEXT;
-    material mat = scene.o[gl_InstanceID].mat;
-    float visibility = 0.0f;
+    int instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
+    material mat = scene.o[instance_id].mat;
 
     vec2 uv;
-    bool back_facing;
-    get_interpolated_vertex_light(view, attribs, gl_InstanceID, gl_PrimitiveID, uv, back_facing);
+    get_interpolated_vertex_light(view, attribs, instance_id, gl_PrimitiveID, uv);
 
-    bool double_sided = mat.emission_factor_double_sided.a > 0.5f;
-    if(!double_sided && back_facing)
-        visibility = 1.0f;
-    else
-    {
-        float alpha = mat.albedo_factor.a;
-        if(mat.albedo_tex_id >= 0)
-            alpha *= texture(textures[nonuniformEXT(mat.albedo_tex_id)], uv).a;
-        visibility = 1.0f-alpha;
-    }
+    float alpha = mat.albedo_factor.a;
+    if(mat.albedo_tex_id >= 0)
+        alpha *= texture(textures[nonuniformEXT(mat.albedo_tex_id)], uv).a;
 
-    shadow_visibility *= visibility;
+    shadow_visibility *= 1.0f-alpha;
     if(shadow_visibility == 0.0f) terminateRayEXT;
     else ignoreIntersectionEXT;
 }

--- a/shader/pre_transform.comp
+++ b/shader/pre_transform.comp
@@ -1,0 +1,39 @@
+#version 460
+#extension GL_EXT_scalar_block_layout : enable
+#extension GL_GOOGLE_include_directive : enable
+#extension GL_EXT_nonuniform_qualifier : enable
+
+#define SCENE_DATA_BUFFER_BINDING 2
+#include "scene.glsl"
+
+layout(local_size_x = 256) in;
+
+layout(binding = 0, set = 0, scalar) readonly buffer input_vertex_buffer
+{
+    vertex v[];
+} input_verts;
+
+layout(binding = 1, set = 0, scalar) writeonly buffer output_vertex_buffer
+{
+    vertex v[];
+} output_verts;
+
+layout(push_constant, scalar) uniform push_constant_buffer
+{
+    uint vertex_count;
+    uint instance_id;
+} control;
+
+void main()
+{
+    uint i = gl_GlobalInvocationID.x;
+    if(i < control.vertex_count)
+    {
+        instance o = scene.o[control.instance_id];
+        vertex v = input_verts.v[i];
+        v.pos = (o.model * vec4(v.pos, 1)).xyz;
+        v.normal = normalize(mat3(o.model_normal) * v.normal);
+        v.tangent = vec4(normalize(mat3(o.model_normal) * v.tangent.xyz), v.tangent.w);
+        output_verts.v[i] = v;
+    }
+}

--- a/shader/pre_transform.comp
+++ b/shader/pre_transform.comp
@@ -34,6 +34,11 @@ void main()
         v.pos = (o.model * vec4(v.pos, 1)).xyz;
         v.normal = normalize(mat3(o.model_normal) * v.normal);
         v.tangent = vec4(normalize(mat3(o.model_normal) * v.tangent.xyz), v.tangent.w);
+        if(determinant(mat3(o.model_normal)) < 0)
+        {
+            v.normal = -v.normal;
+            v.tangent = -v.tangent;
+        }
         output_verts.v[i] = v;
     }
 }

--- a/shader/rt.glsl
+++ b/shader/rt.glsl
@@ -14,6 +14,12 @@ layout(binding = DISTRIBUTION_DATA_BINDING, set = 0) uniform distribution_data_b
 } distribution;
 #endif
 
+#ifdef PRE_TRANSFORMED_VERTICES
+#define TRANSFORM_MAT(name, val) val
+#else
+#define TRANSFORM_MAT(name, val) (name * val)
+#endif
+
 // I would prefer this to be INF, but it's hard to write in glsl.
 #define RAY_MAX_DIST float(1e39)
 
@@ -41,32 +47,38 @@ vertex_data get_interpolated_vertex(vec3 view, vec2 barycentrics, int instance_i
     vertex_data interp;
 
     vec4 model_pos = vec4(v0.pos * b.x + v1.pos * b.y + v2.pos * b.z, 1);
-    interp.pos = (o.model * model_pos).xyz;
+    interp.pos = TRANSFORM_MAT(o.model, model_pos).xyz;
 
 #ifdef NEE_SAMPLE_EMISSIVE_TRIANGLES
     if(o.light_base_id >= 0)
     {
         pdf = sample_triangle_light_pdf(
             interp.pos - pos,
-            (o.model * vec4(v0.pos, 1)).xyz - pos,
-            (o.model * vec4(v1.pos, 1)).xyz - pos,
-            (o.model * vec4(v2.pos, 1)).xyz - pos
+            TRANSFORM_MAT(o.model, vec4(v0.pos, 1)).xyz - pos,
+            TRANSFORM_MAT(o.model, vec4(v1.pos, 1)).xyz - pos,
+            TRANSFORM_MAT(o.model, vec4(v2.pos, 1)).xyz - pos
         );
     }
     else pdf = 0.0f;
 #endif
 
 #ifdef CALC_PREV_VERTEX_POS
+#ifdef PRE_TRANSFORMED_VERTICES
+    interp.prev_pos = (o.model_prev * inverse(o.model) * model_pos).xyz;
+#else
     interp.prev_pos = (o.model_prev * model_pos).xyz;
 #endif
-    interp.smooth_normal = normalize(mat3(o.model_normal) *
-        (v0.normal * b.x + v1.normal * b.y + v2.normal * b.z));
-    interp.tangent = normalize(mat3(o.model_normal) * avg_tangent.xyz);
+#endif
+    interp.smooth_normal = normalize(TRANSFORM_MAT(
+        mat3(o.model_normal),
+        (v0.normal * b.x + v1.normal * b.y + v2.normal * b.z)
+    ));
+    interp.tangent = normalize(TRANSFORM_MAT(mat3(o.model_normal), avg_tangent.xyz));
     interp.bitangent = normalize(cross(interp.smooth_normal, interp.tangent) * avg_tangent.w);
     interp.uv = v0.uv * b.x + v1.uv * b.y + v2.uv * b.z;
 
     // Flip normal if back-facing triangle
-    interp.hard_normal = normalize(mat3(o.model_normal) * cross(v1.pos-v0.pos, v2.pos-v0.pos));
+    interp.hard_normal = normalize(TRANSFORM_MAT(mat3(o.model_normal), cross(v1.pos-v0.pos, v2.pos-v0.pos)));
     interp.back_facing = dot(interp.hard_normal, view) > 0;
     if(interp.back_facing)
     {
@@ -95,7 +107,10 @@ void get_interpolated_vertex_light(vec3 view, vec2 barycentrics, int instance_id
     vec3 b = vec3(1.0f - barycentrics.x - barycentrics.y, barycentrics);
     uv = v0.uv * b.x + v1.uv * b.y + v2.uv * b.z;
 
-    vec3 hard_normal = mat3(o.model_normal) * normalize(cross(v1.pos-v0.pos, v2.pos-v0.pos));
+    vec3 hard_normal = TRANSFORM_MAT(
+        mat3(o.model_normal),
+        normalize(cross(v1.pos-v0.pos, v2.pos-v0.pos))
+    );
     back_facing = dot(hard_normal, view) > 0;
 }
 

--- a/shader/rt.glsl
+++ b/shader/rt.glsl
@@ -92,7 +92,7 @@ vertex_data get_interpolated_vertex(vec3 view, vec2 barycentrics, int instance_i
     return interp;
 }
 
-void get_interpolated_vertex_light(vec3 view, vec2 barycentrics, int instance_id, int primitive_id, out vec2 uv, out bool back_facing)
+void get_interpolated_vertex_light(vec3 view, vec2 barycentrics, int instance_id, int primitive_id, out vec2 uv)
 {
     instance o = scene.o[instance_id];
     ivec3 i = ivec3(
@@ -106,12 +106,6 @@ void get_interpolated_vertex_light(vec3 view, vec2 barycentrics, int instance_id
 
     vec3 b = vec3(1.0f - barycentrics.x - barycentrics.y, barycentrics);
     uv = v0.uv * b.x + v1.uv * b.y + v2.uv * b.z;
-
-    vec3 hard_normal = TRANSFORM_MAT(
-        mat3(o.model_normal),
-        normalize(cross(v1.pos-v0.pos, v2.pos-v0.pos))
-    );
-    back_facing = dot(hard_normal, view) > 0;
 }
 
 sampled_material sample_material(int instance_id, inout vertex_data v)
@@ -123,15 +117,14 @@ sampled_material sample_material(int instance_id, inout vertex_data v)
     return res;
 }
 
-bool is_material_skippable(int instance_id, vec2 uv, bool back_facing, float alpha_cutoff)
+bool is_material_skippable(int instance_id, vec2 uv, float alpha_cutoff)
 {
     material mat = scene.o[instance_id].mat;
     vec4 albedo = mat.albedo_factor;
     if(mat.albedo_tex_id >= 0)
         albedo *= texture(textures[nonuniformEXT(mat.albedo_tex_id)], uv);
 
-    bool double_sided = mat.emission_factor_double_sided.a > 0.5f;
-    return (albedo.a <= alpha_cutoff) || (back_facing && !double_sided);
+    return (albedo.a <= alpha_cutoff);
 }
 
 #endif

--- a/shader/rt.glsl
+++ b/shader/rt.glsl
@@ -26,13 +26,13 @@ vertex_data get_interpolated_vertex(vec3 view, vec2 barycentrics, int instance_i
 {
     instance o = scene.o[instance_id];
     ivec3 i = ivec3(
-        indices[nonuniformEXT(o.mesh_id)].i[3*primitive_id+0],
-        indices[nonuniformEXT(o.mesh_id)].i[3*primitive_id+1],
-        indices[nonuniformEXT(o.mesh_id)].i[3*primitive_id+2]
+        indices[nonuniformEXT(instance_id)].i[3*primitive_id+0],
+        indices[nonuniformEXT(instance_id)].i[3*primitive_id+1],
+        indices[nonuniformEXT(instance_id)].i[3*primitive_id+2]
     );
-    vertex v0 = vertices[nonuniformEXT(o.mesh_id)].v[i.x];
-    vertex v1 = vertices[nonuniformEXT(o.mesh_id)].v[i.y];
-    vertex v2 = vertices[nonuniformEXT(o.mesh_id)].v[i.z];
+    vertex v0 = vertices[nonuniformEXT(instance_id)].v[i.x];
+    vertex v1 = vertices[nonuniformEXT(instance_id)].v[i.y];
+    vertex v2 = vertices[nonuniformEXT(instance_id)].v[i.z];
 
     vec3 b = vec3(1.0f - barycentrics.x - barycentrics.y, barycentrics);
 
@@ -84,13 +84,13 @@ void get_interpolated_vertex_light(vec3 view, vec2 barycentrics, int instance_id
 {
     instance o = scene.o[instance_id];
     ivec3 i = ivec3(
-        indices[nonuniformEXT(o.mesh_id)].i[3*primitive_id+0],
-        indices[nonuniformEXT(o.mesh_id)].i[3*primitive_id+1],
-        indices[nonuniformEXT(o.mesh_id)].i[3*primitive_id+2]
+        indices[nonuniformEXT(instance_id)].i[3*primitive_id+0],
+        indices[nonuniformEXT(instance_id)].i[3*primitive_id+1],
+        indices[nonuniformEXT(instance_id)].i[3*primitive_id+2]
     );
-    vertex v0 = vertices[nonuniformEXT(o.mesh_id)].v[i.x];
-    vertex v1 = vertices[nonuniformEXT(o.mesh_id)].v[i.y];
-    vertex v2 = vertices[nonuniformEXT(o.mesh_id)].v[i.z];
+    vertex v0 = vertices[nonuniformEXT(instance_id)].v[i.x];
+    vertex v1 = vertices[nonuniformEXT(instance_id)].v[i.y];
+    vertex v2 = vertices[nonuniformEXT(instance_id)].v[i.z];
 
     vec3 b = vec3(1.0f - barycentrics.x - barycentrics.y, barycentrics);
     uv = v0.uv * b.x + v1.uv * b.y + v2.uv * b.z;

--- a/shader/rt_feature.rahit
+++ b/shader/rt_feature.rahit
@@ -16,9 +16,9 @@ void main()
 {
     vec3 view = gl_WorldRayDirectionEXT;
     vec2 uv;
-    bool back_facing;
-    get_interpolated_vertex_light(view, attribs, gl_InstanceID, gl_PrimitiveID, uv, back_facing);
-    if(is_material_skippable(gl_InstanceID, uv, back_facing, 0.0001f))
+    int instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
+    get_interpolated_vertex_light(view, attribs, instance_id, gl_PrimitiveID, uv);
+    if(is_material_skippable(instance_id, uv, 0.0001f))
         ignoreIntersectionEXT;
 }
 

--- a/shader/rt_feature.rchit
+++ b/shader/rt_feature.rchit
@@ -21,9 +21,10 @@ layout(location = 0) rayPayloadInEXT hit_payload payload;
 void main()
 {
     vec3 view = gl_WorldRayDirectionEXT;
-    vertex_data v = get_interpolated_vertex(view, attribs, gl_InstanceID, gl_PrimitiveID);
+    int instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
+    vertex_data v = get_interpolated_vertex(view, attribs, instance_id, gl_PrimitiveID);
 
-    sampled_material mat = sample_material(gl_InstanceID, v);
+    sampled_material mat = sample_material(instance_id, v);
     const camera_data cam = get_camera();
     const camera_data prev_cam = get_prev_camera();
 

--- a/shader/scene.glsl
+++ b/shader/scene.glsl
@@ -32,9 +32,9 @@ struct vertex_data
 
 struct instance
 {
-    uint mesh_id;
     int light_base_id;
     int sh_grid_index;
+    uint pad;
     float shadow_terminator_mul;
     mat4 model;
     mat4 model_normal;

--- a/shader/transmission_shadow.rahit
+++ b/shader/transmission_shadow.rahit
@@ -19,42 +19,32 @@ layout(location = 1) rayPayloadInEXT vec3 shadow_transmittance;
 void main()
 {
     vec3 view = gl_WorldRayDirectionEXT;
-    material mat = scene.o[gl_InstanceID].mat;
+    int instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
+    material mat = scene.o[instance_id].mat;
     vec3 transmittance = vec3(0);
     if(mat.transmittance == 0.0f)
     {// Easy case: no transmittance, only potential alpha.
         vec2 uv;
-        bool back_facing;
-        get_interpolated_vertex_light(view, attribs, gl_InstanceID, gl_PrimitiveID, uv, back_facing);
+        get_interpolated_vertex_light(view, attribs, instance_id, gl_PrimitiveID, uv);
 
         bool double_sided = mat.emission_factor_double_sided.a > 0.5f;
-        if(!double_sided && back_facing)
-            transmittance = vec3(1);
-        else
-        {
-            float alpha = mat.albedo_factor.a;
-            if(mat.albedo_tex_id >= 0)
-                alpha *= texture(textures[nonuniformEXT(mat.albedo_tex_id)], uv).a;
-            transmittance = vec3(1.0f-alpha);
-        }
+        float alpha = mat.albedo_factor.a;
+        if(mat.albedo_tex_id >= 0)
+            alpha *= texture(textures[nonuniformEXT(mat.albedo_tex_id)], uv).a;
+        transmittance = vec3(1.0f-alpha);
     }
     else
     { // Hard case with transmittance & possibly alpha as well.
-        vertex_data v = get_interpolated_vertex(view, attribs, gl_InstanceID, gl_PrimitiveID);
-        sampled_material mat = sample_material(gl_InstanceID, v);
-        if(!mat.double_sided && v.back_facing)
-            transmittance = vec3(1);
-        else
-        {
-            mat3 tbn = create_tangent_space(v.mapped_normal);
-            vec3 refr_dir = refract(
-                view, v.mapped_normal, mat.ior_in/mat.ior_out
-            );
-            vec3 d, s;
-            sharp_btdf(refr_dir * tbn, -view * tbn, mat, d, s);
-            vec3 factor = d;
-            transmittance = mix(vec3(1), factor, mat.albedo.a);
-        }
+        vertex_data v = get_interpolated_vertex(view, attribs, instance_id, gl_PrimitiveID);
+        sampled_material mat = sample_material(instance_id, v);
+        mat3 tbn = create_tangent_space(v.mapped_normal);
+        vec3 refr_dir = refract(
+            view, v.mapped_normal, mat.ior_in/mat.ior_out
+        );
+        vec3 d, s;
+        sharp_btdf(refr_dir * tbn, -view * tbn, mat, d, s);
+        vec3 factor = d;
+        transmittance = mix(vec3(1), factor, mat.albedo.a);
     }
 
     shadow_transmittance *= transmittance;

--- a/shader/whitted.rahit
+++ b/shader/whitted.rahit
@@ -17,8 +17,9 @@ layout(location = 0) rayPayloadInEXT hit_payload payload;
 void main()
 {
     // Remove self-intersection if requested
+    int instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
     if(
-        payload.self_instance_id == gl_InstanceID &&
+        payload.self_instance_id == instance_id &&
         payload.self_primitive_id == gl_PrimitiveID
     ){
         ignoreIntersectionEXT;
@@ -27,9 +28,8 @@ void main()
     {
         vec3 view = gl_WorldRayDirectionEXT;
         vec2 uv;
-        bool back_facing;
-        get_interpolated_vertex_light(view, attribs, gl_InstanceID, gl_PrimitiveID, uv, back_facing);
-        if(is_material_skippable(gl_InstanceID, uv, back_facing, 0.0001f))
+        get_interpolated_vertex_light(view, attribs, instance_id, gl_PrimitiveID, uv);
+        if(is_material_skippable(instance_id, uv, 0.0001f))
             ignoreIntersectionEXT;
     }
 }

--- a/shader/whitted.rchit
+++ b/shader/whitted.rchit
@@ -48,7 +48,7 @@ vec4 secondary_ray(vec3 pos, float min_dist, vec3 dir, float max_dist)
     vec4 refl_color = vec4(0,0,0,1);
     if(payload.depth < control.max_depth)
     {
-        payload.self_instance_id = gl_InstanceID;
+        payload.self_instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
         payload.self_primitive_id = gl_PrimitiveID;
         traceRayEXT(
             tlas,
@@ -73,9 +73,10 @@ vec4 secondary_ray(vec3 pos, float min_dist, vec3 dir, float max_dist)
 void main()
 {
     vec3 view = gl_WorldRayDirectionEXT;
-    vertex_data v = get_interpolated_vertex(view, attribs, gl_InstanceID, gl_PrimitiveID);
+    int instance_id = gl_InstanceCustomIndexEXT + gl_GeometryIndexEXT;
+    vertex_data v = get_interpolated_vertex(view, attribs, instance_id, gl_PrimitiveID);
 
-    sampled_material mat = sample_material(gl_InstanceID, v);
+    sampled_material mat = sample_material(instance_id, v);
 
     mat3 tbn = create_tangent_space(v.mapped_normal);
     vec3 shading_view = -view * tbn;

--- a/src/acceleration_structure.cc
+++ b/src/acceleration_structure.cc
@@ -83,11 +83,11 @@ void bottom_level_acceleration_structure::rebuild(
             vk::GeometryTypeKHR::eTriangles,
             vk::AccelerationStructureGeometryTrianglesDataKHR(
                 vk::Format::eR32G32B32Sfloat,
-                dev.dev.getBufferAddress({m->get_vertex_buffer(i)}),
+                dev.dev.getBufferAddress({m->get_vertex_buffer(device_index)}),
                 sizeof(mesh::vertex),
                 m->get_vertices().size()-1,
                 vk::IndexType::eUint32,
-                dev.dev.getBufferAddress({m->get_index_buffer(i)}),
+                dev.dev.getBufferAddress({m->get_index_buffer(device_index)}),
                 transform_address
             ),
             (entries[i].opaque ?

--- a/src/acceleration_structure.cc
+++ b/src/acceleration_structure.cc
@@ -263,6 +263,11 @@ size_t bottom_level_acceleration_structure::get_geometry_count() const
     return geometry_count;
 }
 
+bool bottom_level_acceleration_structure::is_backface_culled() const
+{
+    return backface_culled;
+}
+
 top_level_acceleration_structure::top_level_acceleration_structure(
     context& ctx,
     size_t capacity

--- a/src/acceleration_structure.cc
+++ b/src/acceleration_structure.cc
@@ -1,0 +1,380 @@
+#include "acceleration_structure.hh"
+#include "mesh.hh"
+#include "misc.hh"
+
+namespace tr
+{
+
+bottom_level_acceleration_structure::bottom_level_acceleration_structure(
+    context& ctx,
+    const std::vector<const mesh*>& meshes,
+    const std::vector<const transformable_node*>& transformables,
+    bool backface_culling,
+    bool dynamic
+):  ctx(&ctx), updates_since_rebuild(0), geometry_count(meshes.size()),
+    backface_culling(backface_culling), dynamic(dynamic)
+{
+    std::vector<device_data>& devices = ctx.get_devices();
+    buffers.resize(devices.size());
+
+    for(size_t i = 0; i < devices.size(); ++i)
+    {
+        vk::CommandBuffer cb = begin_command_buffer(devices[i]);
+        rebuild(i, cb, meshes, transformables, false);
+        end_command_buffer(devices[i], cb);
+    }
+}
+
+void bottom_level_acceleration_structure::rebuild(
+    size_t device_index,
+    vk::CommandBuffer cb,
+    const std::vector<const mesh*>& meshes,
+    const std::vector<const transformable_node*>& transformables,
+    bool update
+) {
+    if(!update) updates_since_rebuild = 0;
+    device_data& dev = ctx->get_devices()[device_index];
+
+    std::vector<vk::AccelerationStructureGeometryKHR> geometries(meshes.size());
+    std::vector<vk::TransformMatrixKHR> transforms(meshes.size());
+    std::vector<vk::AccelerationStructureBuildRangeInfoKHR> ranges(meshes.size());
+    std::vector<uint32_t> primitive_count(meshes.size());
+
+    for(size_t i = 0; i < meshes.size(); ++i)
+    {
+        const mesh* m = meshes[i];
+        vk::DeviceOrHostAddressConstKHR transform_address{};
+        if(i < transformables.size())
+        {
+            mat4 transform = transpose(transformables[i]->get_global_transform());
+            memcpy(
+                (void*)&transforms[i],
+                (void*)&transform,
+                sizeof(vk::TransformMatrixKHR)
+            );
+            transform_address.hostAddress = &transforms[i];
+        }
+        geometries[i] = {
+            vk::GeometryTypeKHR::eTriangles,
+            vk::AccelerationStructureGeometryTrianglesDataKHR(
+                vk::Format::eR32G32B32Sfloat,
+                dev.dev.getBufferAddress({m->get_vertex_buffer(i)}),
+                sizeof(mesh::vertex),
+                m->get_vertices().size()-1,
+                vk::IndexType::eUint32,
+                dev.dev.getBufferAddress({m->get_index_buffer(i)}),
+                transform_address
+            ),
+            m->get_opaque() ?
+                vk::GeometryFlagBitsKHR::eOpaque :
+                vk::GeometryFlagBitsKHR::eNoDuplicateAnyHitInvocation
+        };
+        uint32_t triangle_count = m->get_indices().size()/3;
+        ranges[i] = vk::AccelerationStructureBuildRangeInfoKHR{triangle_count, 0, 0, 0};
+        primitive_count[i] = triangle_count;
+    }
+
+    vk::AccelerationStructureBuildGeometryInfoKHR blas_info(
+        vk::AccelerationStructureTypeKHR::eBottomLevel,
+        dynamic ?
+            vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastBuild|
+            vk::BuildAccelerationStructureFlagBitsKHR::eAllowUpdate :
+            vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace|
+            vk::BuildAccelerationStructureFlagBitsKHR::eAllowCompaction,
+        update ?
+            vk::BuildAccelerationStructureModeKHR::eUpdate :
+            vk::BuildAccelerationStructureModeKHR::eBuild,
+        VK_NULL_HANDLE,
+        VK_NULL_HANDLE,
+        geometries.size(),
+        geometries.data()
+    );
+
+    buffer_data& bd = buffers[device_index];
+    if(!bd.blas || !dynamic)
+    {
+        // Need to calculate BLAS size.
+        vk::AccelerationStructureBuildSizesInfoKHR size_info = dev.dev.getAccelerationStructureBuildSizesKHR(
+            vk::AccelerationStructureBuildTypeKHR::eDevice, blas_info, primitive_count
+        );
+        vk::BufferCreateInfo scratch_info(
+            {}, size_info.buildScratchSize,
+            vk::BufferUsageFlagBits::eStorageBuffer|
+            vk::BufferUsageFlagBits::eShaderDeviceAddress,
+            vk::SharingMode::eExclusive
+        );
+        bd.scratch_buffer = create_buffer_aligned(
+            dev, scratch_info, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT,
+            dev.as_props.minAccelerationStructureScratchOffsetAlignment
+        );
+        bd.scratch_address = bd.scratch_buffer.get_address();
+
+        vk::BufferCreateInfo blas_buffer_info(
+            {}, size_info.accelerationStructureSize,
+            vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR|
+            vk::BufferUsageFlagBits::eShaderDeviceAddress,
+            vk::SharingMode::eExclusive
+        );
+        bd.blas_buffer = create_buffer(dev, blas_buffer_info, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT);
+
+        vk::AccelerationStructureCreateInfoKHR create_info(
+            {},
+            bd.blas_buffer,
+            {},
+            size_info.accelerationStructureSize,
+            vk::AccelerationStructureTypeKHR::eBottomLevel,
+            {}
+        );
+        bd.blas = vkm(dev, dev.dev.createAccelerationStructureKHR(create_info));
+    }
+    blas_info.srcAccelerationStructure = update ? *bd.blas : VK_NULL_HANDLE;
+    blas_info.dstAccelerationStructure = bd.blas;
+    blas_info.scratchData.deviceAddress = bd.scratch_address;
+
+    const vk::AccelerationStructureBuildRangeInfoKHR* range_ptr = ranges.data();
+
+    vkm<vk::QueryPool> query_pool;
+    vk::CommandBuffer initial_cb;
+    if(!dynamic)
+    {
+        initial_cb = begin_command_buffer(dev);
+        query_pool = vkm(dev, dev.dev.createQueryPool({
+            {},
+            vk::QueryType::eAccelerationStructureCompactedSizeKHR,
+            1,
+            {}
+        }));
+        initial_cb.resetQueryPool(query_pool, 0, 1);
+        initial_cb.buildAccelerationStructuresKHR({blas_info}, range_ptr);
+
+        vk::MemoryBarrier barrier(
+            vk::AccessFlagBits::eAccelerationStructureWriteKHR,
+            vk::AccessFlagBits::eAccelerationStructureReadKHR
+        );
+        initial_cb.pipelineBarrier(
+            vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+            vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+            {}, barrier, {}, {}
+        );
+
+        initial_cb.writeAccelerationStructuresPropertiesKHR(
+            *bd.blas,
+            vk::QueryType::eAccelerationStructureCompactedSizeKHR,
+            query_pool,
+            0
+        );
+        end_command_buffer(dev, initial_cb);
+
+        // NVIDIA bug as of 460.27.04: Only the lower 32 bits of the parameter
+        // get written to, despite the spec saying that it's supposed to be a
+        // VkDeviceSize (uint64_t). We need to make sure that the size is
+        // zero-initialized to avoid the higher 32 bits breaking everything.
+        vk::DeviceSize compact_size = 0;
+        (void)dev.dev.getQueryPoolResults(
+            query_pool, 0, 1,
+            sizeof(vk::DeviceSize),
+            &compact_size,
+            sizeof(vk::DeviceSize),
+            vk::QueryResultFlagBits::eWait
+        );
+
+        vkm<vk::AccelerationStructureKHR> fat_blas = std::move(bd.blas);
+        vkm<vk::Buffer> fat_blas_buffer(std::move(bd.blas_buffer));
+
+        vk::BufferCreateInfo blas_buffer_info(
+            {}, compact_size,
+            vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR|
+            vk::BufferUsageFlagBits::eShaderDeviceAddress,
+            vk::SharingMode::eExclusive
+        );
+
+        bd.blas_buffer = create_buffer(dev, blas_buffer_info, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT);
+        vk::AccelerationStructureCreateInfoKHR create_info(
+            {},
+            bd.blas_buffer,
+            {},
+            compact_size,
+            vk::AccelerationStructureTypeKHR::eBottomLevel,
+            {}
+        );
+
+        bd.blas = vkm(dev, dev.dev.createAccelerationStructureKHR(create_info));
+        blas_info.dstAccelerationStructure = bd.blas;
+
+        cb.copyAccelerationStructureKHR({
+            fat_blas,
+            bd.blas,
+            vk::CopyAccelerationStructureModeKHR::eCompact
+        });
+
+        fat_blas.drop();
+        fat_blas_buffer.drop();
+    }
+    else
+    {
+        cb.buildAccelerationStructuresKHR({blas_info}, range_ptr);
+    }
+    bd.blas_address = dev.dev.getAccelerationStructureAddressKHR({bd.blas});
+}
+
+size_t bottom_level_acceleration_structure::get_updates_since_rebuild() const
+{
+    return updates_since_rebuild;
+}
+
+vk::AccelerationStructureKHR bottom_level_acceleration_structure::get_blas_handle(size_t device_index) const
+{
+    return *buffers[device_index].blas;
+}
+
+vk::DeviceAddress bottom_level_acceleration_structure::get_blas_address(size_t device_index) const
+{
+    return buffers[device_index].blas_address;
+}
+
+top_level_acceleration_structure::top_level_acceleration_structure(
+    context& ctx,
+    size_t capacity
+):  ctx(&ctx), updates_since_rebuild(0), instance_count(0),
+    instance_capacity(capacity), require_rebuild(true)
+{
+    std::vector<device_data>& devices = ctx.get_devices();
+    buffers.resize(devices.size());
+    for(size_t i = 0; i < devices.size(); ++i)
+    {
+        buffer_data& bd = buffers[i];
+        bd.instance_buffer = gpu_buffer(
+            devices[i],
+            capacity * sizeof(VkAccelerationStructureInstanceKHR),
+            vk::BufferUsageFlagBits::eStorageBuffer |
+            vk::BufferUsageFlagBits::eTransferDst |
+            vk::BufferUsageFlagBits::eShaderDeviceAddress|
+            vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR
+        );
+        vk::AccelerationStructureGeometryKHR geom(
+            VULKAN_HPP_NAMESPACE::GeometryTypeKHR::eInstances,
+            vk::AccelerationStructureGeometryInstancesDataKHR{
+                VK_FALSE, bd.instance_buffer.get_address()
+            }
+        );
+
+        vk::AccelerationStructureBuildGeometryInfoKHR tlas_info(
+            vk::AccelerationStructureTypeKHR::eTopLevel,
+            vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace|
+            vk::BuildAccelerationStructureFlagBitsKHR::eAllowUpdate,
+            vk::BuildAccelerationStructureModeKHR::eBuild,
+            VK_NULL_HANDLE,
+            VK_NULL_HANDLE,
+            1,
+            &geom
+        );
+
+        vk::AccelerationStructureBuildSizesInfoKHR size_info =
+            devices[i].dev.getAccelerationStructureBuildSizesKHR(
+                vk::AccelerationStructureBuildTypeKHR::eDevice, tlas_info, {(uint32_t)capacity}
+            );
+
+        vk::BufferCreateInfo tlas_buffer_info(
+            {}, size_info.accelerationStructureSize,
+            vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR|
+            vk::BufferUsageFlagBits::eShaderDeviceAddress,
+            vk::SharingMode::eExclusive
+        );
+        bd.tlas_buffer = create_buffer(devices[i], tlas_buffer_info, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT);
+
+        vk::AccelerationStructureCreateInfoKHR create_info(
+            {},
+            bd.tlas_buffer,
+            {},
+            size_info.accelerationStructureSize,
+            vk::AccelerationStructureTypeKHR::eTopLevel,
+            {}
+        );
+        bd.tlas = vkm(devices[i], devices[i].dev.createAccelerationStructureKHR(create_info));
+        tlas_info.dstAccelerationStructure = bd.tlas;
+
+        vk::BufferCreateInfo scratch_info(
+            {}, size_info.buildScratchSize,
+            vk::BufferUsageFlagBits::eStorageBuffer|
+            vk::BufferUsageFlagBits::eShaderDeviceAddress,
+            vk::SharingMode::eExclusive
+        );
+
+        bd.scratch_buffer = create_buffer_aligned(
+            devices[i], scratch_info, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT,
+            devices[i].as_props.minAccelerationStructureScratchOffsetAlignment
+        );
+        tlas_info.scratchData = bd.scratch_buffer.get_address();
+        bd.tlas_address = devices[i].dev.getAccelerationStructureAddressKHR({bd.tlas});
+    }
+}
+
+gpu_buffer& top_level_acceleration_structure::get_instances_buffer(size_t device_index)
+{
+    return buffers[device_index].instance_buffer;
+}
+
+void top_level_acceleration_structure::rebuild(
+    size_t device_index,
+    vk::CommandBuffer cb,
+    size_t instance_count,
+    bool update
+){
+    buffer_data& bd = buffers[device_index];
+
+    // Barrier to make sure all BLAS's have updated already.
+    vk::MemoryBarrier blas_barrier(
+        vk::AccessFlagBits::eAccelerationStructureWriteKHR,
+        vk::AccessFlagBits::eAccelerationStructureWriteKHR
+    );
+
+    cb.pipelineBarrier(
+        vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+        vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
+        {}, blas_barrier, {}, {}
+    );
+
+    vk::AccelerationStructureGeometryKHR tlas_geometry(
+        vk::GeometryTypeKHR::eInstances,
+        vk::AccelerationStructureGeometryInstancesDataKHR{
+            false, bd.instance_buffer.get_address()
+        },
+        {}
+    );
+
+    vk::AccelerationStructureBuildGeometryInfoKHR tlas_info(
+        vk::AccelerationStructureTypeKHR::eTopLevel,
+        vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace|
+        vk::BuildAccelerationStructureFlagBitsKHR::eAllowUpdate,
+        update ? vk::BuildAccelerationStructureModeKHR::eUpdate : vk::BuildAccelerationStructureModeKHR::eBuild,
+        update ? bd.tlas : vk::AccelerationStructureKHR{},
+        bd.tlas,
+        1,
+        &tlas_geometry,
+        nullptr,
+        bd.scratch_buffer.get_address()
+    );
+
+    vk::AccelerationStructureBuildRangeInfoKHR build_offset_info(
+        instance_count, 0, 0, 0
+    );
+
+    cb.buildAccelerationStructuresKHR({tlas_info}, {&build_offset_info});
+}
+
+size_t top_level_acceleration_structure::get_updates_since_rebuild() const
+{
+    return updates_since_rebuild;
+}
+
+const vk::AccelerationStructureKHR* top_level_acceleration_structure::get_tlas_handle(size_t device_index) const
+{
+    return buffers[device_index].tlas;
+}
+
+vk::DeviceAddress top_level_acceleration_structure::get_tlas_address(size_t device_index) const
+{
+    return buffers[device_index].tlas_address;
+}
+
+}

--- a/src/acceleration_structure.hh
+++ b/src/acceleration_structure.hh
@@ -43,6 +43,7 @@ public:
     vk::DeviceAddress get_blas_address(size_t device_index) const;
 
     size_t get_geometry_count() const;
+    bool is_backface_culled() const;
 
 private:
     context* ctx;

--- a/src/acceleration_structure.hh
+++ b/src/acceleration_structure.hh
@@ -23,7 +23,8 @@ public:
         context& ctx,
         const std::vector<entry>& entries,
         bool backface_culled,
-        bool dynamic
+        bool dynamic,
+        bool compact
     );
 
     void update_transforms(
@@ -51,6 +52,7 @@ private:
     size_t geometry_count;
     bool backface_culled;
     bool dynamic;
+    bool compact;
 
     // Per-device
     struct buffer_data

--- a/src/acceleration_structure.hh
+++ b/src/acceleration_structure.hh
@@ -1,0 +1,94 @@
+#ifndef TAURAY_ACCELERATION_STRUCTURE_HH
+#define TAURAY_ACCELERATION_STRUCTURE_HH
+#include "context.hh"
+#include "transformable.hh"
+#include "gpu_buffer.hh"
+#include "vkm.hh"
+
+namespace tr
+{
+
+class mesh;
+class bottom_level_acceleration_structure
+{
+public:
+    bottom_level_acceleration_structure(
+        context& ctx,
+        const std::vector<const mesh*>& meshes,
+        const std::vector<const transformable_node*>& transformables,
+        bool backface_culling,
+        bool dynamic
+    );
+
+    void rebuild(
+        size_t device_index,
+        vk::CommandBuffer cb,
+        const std::vector<const mesh*>& meshes,
+        const std::vector<const transformable_node*>& transformables,
+        bool update = true
+    );
+    size_t get_updates_since_rebuild() const;
+    vk::AccelerationStructureKHR get_blas_handle(size_t device_index) const;
+    vk::DeviceAddress get_blas_address(size_t device_index) const;
+
+private:
+    context* ctx;
+    size_t updates_since_rebuild;
+    size_t geometry_count;
+    bool backface_culling;
+    bool dynamic;
+
+    // Per-device
+    struct buffer_data
+    {
+        vkm<vk::AccelerationStructureKHR> blas;
+        vkm<vk::Buffer> blas_buffer;
+        vk::DeviceAddress blas_address;
+        vkm<vk::Buffer> scratch_buffer;
+        vk::DeviceAddress scratch_address;
+    };
+    std::vector<buffer_data> buffers;
+};
+
+class top_level_acceleration_structure
+{
+public:
+    top_level_acceleration_structure(
+        context& ctx,
+        size_t capacity
+    );
+
+    gpu_buffer& get_instances_buffer(size_t device_index);
+    void rebuild(
+        size_t device_index,
+        vk::CommandBuffer cb,
+        size_t instance_count,
+        bool update
+    );
+    size_t get_updates_since_rebuild() const;
+    const vk::AccelerationStructureKHR* get_tlas_handle(size_t device_index) const;
+    vk::DeviceAddress get_tlas_address(size_t device_index) const;
+
+private:
+    context* ctx;
+
+    size_t updates_since_rebuild;
+    size_t instance_count;
+    size_t instance_capacity;
+    bool require_rebuild;
+
+    // Per-device
+    struct buffer_data
+    {
+        vkm<vk::AccelerationStructureKHR> tlas;
+        vkm<vk::Buffer> tlas_buffer;
+        vkm<vk::Buffer> scratch_buffer;
+        vk::DeviceAddress tlas_address;
+        gpu_buffer instance_buffer;
+    };
+    std::vector<buffer_data> buffers;
+};
+
+}
+
+#endif

--- a/src/acceleration_structure.hh
+++ b/src/acceleration_structure.hh
@@ -12,35 +12,49 @@ class mesh;
 class bottom_level_acceleration_structure
 {
 public:
+    struct entry
+    {
+        const mesh* m = nullptr;
+        mat4 transform = mat4(1);
+        bool opaque = true;
+    };
+
     bottom_level_acceleration_structure(
         context& ctx,
-        const std::vector<const mesh*>& meshes,
-        const std::vector<const transformable_node*>& transformables,
-        bool backface_culling,
+        const std::vector<entry>& entries,
+        bool backface_culled,
         bool dynamic
+    );
+
+    void update_transforms(
+        size_t frame_index,
+        const std::vector<entry>& entries
     );
 
     void rebuild(
         size_t device_index,
+        size_t frame_index,
         vk::CommandBuffer cb,
-        const std::vector<const mesh*>& meshes,
-        const std::vector<const transformable_node*>& transformables,
+        const std::vector<entry>& entries,
         bool update = true
     );
     size_t get_updates_since_rebuild() const;
     vk::AccelerationStructureKHR get_blas_handle(size_t device_index) const;
     vk::DeviceAddress get_blas_address(size_t device_index) const;
 
+    size_t get_geometry_count() const;
+
 private:
     context* ctx;
     size_t updates_since_rebuild;
     size_t geometry_count;
-    bool backface_culling;
+    bool backface_culled;
     bool dynamic;
 
     // Per-device
     struct buffer_data
     {
+        gpu_buffer transform_buffer;
         vkm<vk::AccelerationStructureKHR> blas;
         vkm<vk::Buffer> blas_buffer;
         vk::DeviceAddress blas_address;

--- a/src/feature_stage.cc
+++ b/src/feature_stage.cc
@@ -42,7 +42,7 @@ namespace feature
             feature = "vec4(get_camera_projection(prev_cam, v.prev_pos), 0, 1)";
             break;
         case feature_stage::INSTANCE_ID:
-            feature = "vec4(gl_InstanceID, gl_PrimitiveID, scene.o[gl_InstanceID].mesh_id, 1)";
+            feature = "vec4(gl_InstanceID, gl_PrimitiveID, 0, 1)";
             break;
         }
         std::map<std::string, std::string> defines;

--- a/src/gltf.cc
+++ b/src/gltf.cc
@@ -748,11 +748,6 @@ scene_graph load_gltf(
             if(generate_tangents)
                 prim_mesh->calculate_tangents();
 
-            prim_mesh->set_opaque(
-                !primitive_material.potentially_transparent() &&
-                primitive_material.double_sided
-            );
-
             md.meshes.emplace_back(prim_mesh);
             m.add_vertex_group(primitive_material, prim_mesh);
         }

--- a/src/heightfield.cc
+++ b/src/heightfield.cc
@@ -7,7 +7,6 @@ namespace tr
 heightfield::heightfield(context& ctx, const std::string& path, vec3 scale)
 : mesh(ctx)
 {
-    set_opaque(true);
     std::vector<mesh::vertex>& vertex_data = get_vertices();
     std::vector<uint32_t>& index_data = get_indices();
 

--- a/src/material.hh
+++ b/src/material.hh
@@ -39,9 +39,10 @@ struct combined_tex_sampler_hash
 {
     size_t operator()(const combined_tex_sampler & v) const
     {
-        size_t a = std::hash<const texture*>()(v.first);
-        size_t b = std::hash<const sampler*>()(v.second);
-        return a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2));
+        return hash_combine(
+            std::hash<const texture*>()(v.first),
+            std::hash<const sampler*>()(v.second)
+        );
     }
 };
 

--- a/src/math.cc
+++ b/src/math.cc
@@ -321,4 +321,9 @@ std::vector<vec2> get_camera_jitter_sequence(
     return seq;
 }
 
+size_t hash_combine(size_t a, size_t b)
+{
+    return a ^ (b + 0x9e3779b9 + (a << 6) + (a >> 2));
+}
+
 }

--- a/src/math.hh
+++ b/src/math.hh
@@ -156,6 +156,8 @@ std::vector<vec2> get_camera_jitter_sequence(
     int sequence_length, uvec2 resolution
 );
 
+size_t hash_combine(size_t a, size_t b);
+
 }
 
 #include "math.tcc"

--- a/src/mesh.hh
+++ b/src/mesh.hh
@@ -5,6 +5,8 @@
 #include "material.hh"
 #include "transformable.hh"
 #include "gpu_buffer.hh"
+#include "acceleration_structure.hh"
+#include <optional>
 
 namespace tr
 {
@@ -81,6 +83,7 @@ public:
     // alpha effects will not work on them. The change will not take effect
     // until upload() is called.
     void set_opaque(bool opaque);
+    bool get_opaque() const;
 
     // If you modify vertices or indices after constructor call, use this to
     // reload the GPU buffer(s). If you give the command buffers, uploads are
@@ -113,13 +116,9 @@ private:
         vkm<vk::Buffer> vertex_buffer;
         vkm<vk::Buffer> index_buffer;
         vkm<vk::Buffer> skin_buffer;
-
-        vkm<vk::AccelerationStructureKHR> blas;
-        vkm<vk::Buffer> blas_buffer;
-        vk::DeviceAddress blas_address;
-        vkm<vk::Buffer> blas_scratch_buffer;
     };
     std::vector<buffer_data> buffers;
+    mutable std::optional<bottom_level_acceleration_structure> blas;
 };
 
 }

--- a/src/mesh_scene.cc
+++ b/src/mesh_scene.cc
@@ -408,6 +408,8 @@ void mesh_scene::invalidate_tlas()
 
 void mesh_scene::ensure_blas()
 {
+    if(!ctx->is_ray_tracing_supported())
+        return;
     // Goes through all groups and ensures they have valid BLASes.
     size_t offset = 0;
     std::vector<bottom_level_acceleration_structure::entry> entries;

--- a/src/mesh_scene.hh
+++ b/src/mesh_scene.hh
@@ -41,6 +41,17 @@ public:
     void refresh_instance_cache(bool force = false);
     const std::vector<instance>& get_instances() const;
 
+    bool reserve_pre_transformed_vertices(size_t device_index, size_t max_vertex_count);
+    void clear_pre_transformed_vertices(size_t device_index);
+    vk::Buffer get_pre_transformed_vertices(size_t device_index);
+
+    std::vector<vk::DescriptorBufferInfo> get_vertex_buffer_bindings(
+        size_t device_index
+    ) const;
+    std::vector<vk::DescriptorBufferInfo> get_index_buffer_bindings(
+        size_t device_index
+    ) const;
+
 protected:
     template<typename F>
     void visit_animated(F&& f) const
@@ -88,6 +99,7 @@ private:
     struct acceleration_structure_data
     {
         bool scene_reset_needed = true;
+        uint32_t pre_transformed_vertex_count = 0;
         vkm<vk::Buffer> pre_transformed_vertices;
 
         struct per_frame_data

--- a/src/mesh_scene.hh
+++ b/src/mesh_scene.hh
@@ -20,12 +20,9 @@ public:
     void remove(mesh_object& o);
     void clear_mesh_objects();
     const std::vector<mesh_object*>& get_mesh_objects() const;
-    const std::vector<std::pair<const mesh*, int>>& get_meshes() const;
     size_t get_instance_count() const;
     // This can be very slow!
     size_t get_sampler_count() const;
-    size_t get_mesh_count() const;
-    unsigned find_mesh_id(const mesh* m) const;
 
     struct instance
     {
@@ -81,20 +78,17 @@ protected:
 
 private:
     void invalidate_acceleration_structures();
-    void invalidate_mesh_ids();
-    std::vector<std::pair<const mesh*, int>>::iterator find_mesh(const mesh* m);
 
     context* ctx;
     size_t max_capacity;
     std::vector<mesh_object*> objects;
-    std::vector<std::pair<const mesh*, int/*count*/>> meshes;
-    mutable std::unordered_map<const mesh*, unsigned> mesh_ids;
 
     // The meshes contain the acceleration structures themselves, so we only
     // have to track scene & command buffer validity!
     struct acceleration_structure_data
     {
         bool scene_reset_needed = true;
+        vkm<vk::Buffer> pre_transformed_vertices;
 
         struct per_frame_data
         {

--- a/src/mesh_scene.hh
+++ b/src/mesh_scene.hh
@@ -116,9 +116,23 @@ private:
         };
         per_frame_data per_frame[MAX_FRAMES_IN_FLIGHT];
     };
+
+    // For acceleration structures, instances are grouped by which ones go into
+    // the same BLAS. If two groups share the same ID, they will have the same
+    // acceleration structure as well, but are inserted as separate TLAS
+    // instances still.
+    struct instance_group
+    {
+        uint64_t id = 0;
+        size_t size = 0;
+        bool static_mesh = false;
+        bool static_transformable = false;
+    };
+
     std::vector<as_update_data> as_update;
-    std::unordered_map<uint64_t, bottom_level_acceleration_structure> per_mesh_blas_cache;
+    std::unordered_map<uint64_t, bottom_level_acceleration_structure> blas_cache;
     std::vector<instance> instance_cache;
+    std::vector<instance_group> group_cache;
     uint64_t instance_cache_frame;
 };
 

--- a/src/mesh_scene.hh
+++ b/src/mesh_scene.hh
@@ -9,6 +9,14 @@
 namespace tr
 {
 
+enum class blas_strategy
+{
+    PER_MATERIAL,
+    PER_MODEL,
+    STATIC_MERGED_DYNAMIC_PER_MODEL,
+    ALL_MERGED_STATIC
+};
+
 class mesh_scene
 {
 public:
@@ -53,6 +61,8 @@ public:
         size_t device_index
     ) const;
 
+    void set_blas_strategy(blas_strategy strat);
+    size_t get_blas_group_count() const;
     void refresh_dynamic_acceleration_structures(
         size_t device_index,
         size_t frame_index,
@@ -97,6 +107,13 @@ protected:
 private:
     void invalidate_tlas();
     void ensure_blas();
+    void assign_group_cache(
+        uint64_t id,
+        bool static_mesh,
+        bool static_transformable,
+        size_t object_index,
+        size_t& last_object_index
+    );
 
     context* ctx;
     size_t max_capacity;
@@ -133,6 +150,7 @@ private:
     std::unordered_map<uint64_t, bottom_level_acceleration_structure> blas_cache;
     std::vector<instance> instance_cache;
     std::vector<instance_group> group_cache;
+    blas_strategy group_strategy;
     uint64_t instance_cache_frame;
 };
 

--- a/src/options.hh
+++ b/src/options.hh
@@ -483,6 +483,20 @@
         "Increases memory usage, but speeds up multi-bounce path tracing " \
         "performance.", \
         false \
+    )\
+    TR_ENUM_OPT(as_strategy, blas_strategy, \
+        "Acceleration structure strategy; i.e. how geometries are assigned " \
+        "into BLASes. per-material assigns each material of each model a " \
+        "different BLAS. per-model assigns each model a BLAS. " \
+        "static-merged-dynamic-per-model merges all static geometries into " \
+        "one BLAS, while dynamic geometries are given per-model BLASes. " \
+        "all-merged puts everything in one. Each approach has different " \
+        "performance and memory tradeoffs.", \
+        blas_strategy::STATIC_MERGED_DYNAMIC_PER_MODEL, \
+        {"per-material", blas_strategy::PER_MATERIAL}, \
+        {"per-model", blas_strategy::PER_MODEL}, \
+        {"static-merged-dynamic-per-model", blas_strategy::STATIC_MERGED_DYNAMIC_PER_MODEL}, \
+        {"all-merged", blas_strategy::ALL_MERGED_STATIC} \
     )
 //==============================================================================
 // END OF OPTIONS
@@ -497,6 +511,7 @@
 #include "feature_stage.hh"
 #include "raster_stage.hh"
 #include "camera.hh"
+#include "mesh_scene.hh"
 #include <string>
 #include <variant>
 #include <stdexcept>

--- a/src/options.hh
+++ b/src/options.hh
@@ -478,6 +478,12 @@
         "Shows the scene stats including triangles count, static and dynamic objects count, texture count, and the number of light sources.", \
         false \
     ) \
+    TR_BOOL_OPT(pre_transform_vertices, \
+        "Pre-calculate transformed vertices into a separate buffer." \
+        "Increases memory usage, but speeds up multi-bounce path tracing " \
+        "performance.", \
+        false \
+    )
 //==============================================================================
 // END OF OPTIONS
 //==============================================================================

--- a/src/ply.cc
+++ b/src/ply.cc
@@ -160,7 +160,6 @@ void init_ply(
     mat.double_sided = !force_single_sided;
 
     mesh* primitive = new mesh(ctx);
-    primitive->set_opaque(true);
     primitive->get_vertices() = {{}, {}, {}};
     primitive->get_indices() = {0,1,2};
     sg.meshes.emplace_back(primitive);

--- a/src/rt_renderer.cc
+++ b/src/rt_renderer.cc
@@ -252,7 +252,7 @@ void rt_renderer<Pipeline>::init_device_resources(size_t device_index)
 
     per_device_data& r = per_device[device_index];
     r.per_frame.resize(MAX_FRAMES_IN_FLIGHT);
-    r.skinning.reset(new skinning_stage(d, opt.max_meshes));
+    r.skinning.reset(new skinning_stage(d, opt.max_instances));
     r.scene_update.reset(new scene_update_stage(d, opt.scene_options));
     r.dist = get_device_distribution_params(
         ctx->get_size(),

--- a/src/rt_renderer.cc
+++ b/src/rt_renderer.cc
@@ -84,6 +84,7 @@ void rt_renderer<Pipeline>::set_scene(scene* s)
     opt.projection = s->get_camera(0)->get_projection_type();
     if(s)
     {
+        s->refresh_instance_cache(true);
         for(size_t i = 0; i < per_device.size(); ++i)
         {
             per_device[i].skinning->set_scene(s);

--- a/src/rt_stage.cc
+++ b/src/rt_stage.cc
@@ -68,6 +68,9 @@ void rt_stage::get_common_defines(
     default:
         break;
     }
+
+    if(opt.pre_transformed_vertices)
+        defines["PRE_TRANSFORMED_VERTICES"];
 }
 
 rt_stage::rt_stage(

--- a/src/rt_stage.cc
+++ b/src/rt_stage.cc
@@ -36,8 +36,8 @@ gfx_pipeline::pipeline_state rt_stage::get_common_state(
         viewport,
         src,
         {
-            {"vertices", (uint32_t)opt.max_meshes},
-            {"indices", (uint32_t)opt.max_meshes},
+            {"vertices", (uint32_t)opt.max_instances},
+            {"indices", (uint32_t)opt.max_instances},
             {"textures", (uint32_t)opt.max_samplers},
         },
         mesh::get_bindings(),
@@ -95,7 +95,7 @@ rt_stage::rt_stage(
 void rt_stage::set_scene(scene* s)
 {
     cur_scene = s;
-    if(s->get_meshes().size() > opt.max_meshes)
+    if(s->get_instance_count() > opt.max_instances)
         throw std::runtime_error(
             "The scene has more meshes than this pipeline can support!"
         );
@@ -139,8 +139,8 @@ void rt_stage::init_resources()
     // Init descriptor set references to some placeholder value to silence
     // the validation layer (these should never actually be accessed)
     gfx.update_descriptor_set({
-        {"vertices", opt.max_meshes},
-        {"indices", opt.max_meshes},
+        {"vertices", opt.max_instances},
+        {"indices", opt.max_instances},
         {"textures", opt.max_samplers}
     });
     for(size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)

--- a/src/rt_stage.hh
+++ b/src/rt_stage.hh
@@ -27,7 +27,7 @@ public:
 
     struct options
     {
-        size_t max_meshes = 1024;
+        size_t max_instances = 1024;
         size_t max_samplers = 128;
 
         int max_ray_depth = 8;

--- a/src/rt_stage.hh
+++ b/src/rt_stage.hh
@@ -33,6 +33,8 @@ public:
         int max_ray_depth = 8;
         float min_ray_dist = 0.001f;
 
+        bool pre_transformed_vertices = false;
+
         int rng_seed = 0;
         sampler_type local_sampler  = sampler_type::UNIFORM_RANDOM;
     };

--- a/src/scene.cc
+++ b/src/scene.cc
@@ -161,8 +161,7 @@ vk::AccelerationStructureKHR scene::get_acceleration_structure(
         throw std::runtime_error(
             "Trying to use TLAS, but ray tracing is not available!"
         );
-    auto& as = acceleration_structures[device_index];
-    return as.tlas;
+    return *tlas->get_tlas_handle(device_index);
 }
 
 void scene::set_shadow_map_renderer(shadow_map_renderer* smr)
@@ -244,9 +243,7 @@ std::vector<descriptor_state> scene::get_descriptor_info(device_data* dev, int32
 
     if(ctx->is_ray_tracing_supported())
     {
-        descriptors.push_back(
-            {"tlas", {1, acceleration_structures[dev->index].tlas}}
-        );
+        descriptors.push_back({"tlas", {1, this->tlas->get_tlas_handle(dev->index)}});
     }
 
     if(smr)
@@ -326,84 +323,8 @@ void scene::init_acceleration_structures()
 {
     if(!ctx->is_ray_tracing_supported()) return;
 
-    std::vector<device_data>& devices = ctx->get_devices();
-    acceleration_structures.resize(devices.size());
-
-    for(size_t i = 0; i < devices.size(); ++i)
-    {
-        init_tlas(i);
-    }
-}
-
-void scene::init_tlas(size_t i)
-{
-    std::vector<device_data>& devices = ctx->get_devices();
-    auto& as = acceleration_structures[i];
-
     uint32_t total_max_capacity = mesh_scene::get_max_capacity() + light_scene::get_max_capacity();
-    as.instance_buffer = gpu_buffer(
-        devices[i],
-        total_max_capacity * sizeof(VkAccelerationStructureInstanceKHR),
-        vk::BufferUsageFlagBits::eStorageBuffer |
-        vk::BufferUsageFlagBits::eTransferDst |
-        vk::BufferUsageFlagBits::eShaderDeviceAddress|
-        vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR
-    );
-
-    vk::AccelerationStructureGeometryKHR geom(
-        VULKAN_HPP_NAMESPACE::GeometryTypeKHR::eInstances,
-        vk::AccelerationStructureGeometryInstancesDataKHR{
-            VK_FALSE, as.instance_buffer.get_address()
-        }
-    );
-
-    vk::AccelerationStructureBuildGeometryInfoKHR tlas_info(
-        vk::AccelerationStructureTypeKHR::eTopLevel,
-        vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace|
-        vk::BuildAccelerationStructureFlagBitsKHR::eAllowUpdate,
-        vk::BuildAccelerationStructureModeKHR::eBuild,
-        VK_NULL_HANDLE,
-        VK_NULL_HANDLE,
-        1,
-        &geom
-    );
-
-    vk::AccelerationStructureBuildSizesInfoKHR size_info =
-        devices[i].dev.getAccelerationStructureBuildSizesKHR(
-            vk::AccelerationStructureBuildTypeKHR::eDevice, tlas_info, {total_max_capacity}
-        );
-
-    vk::BufferCreateInfo tlas_buffer_info(
-        {}, size_info.accelerationStructureSize,
-        vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR|
-        vk::BufferUsageFlagBits::eShaderDeviceAddress,
-        vk::SharingMode::eExclusive
-    );
-    as.tlas_buffer = create_buffer(devices[i], tlas_buffer_info, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT);
-
-    vk::AccelerationStructureCreateInfoKHR create_info(
-        {},
-        as.tlas_buffer,
-        {},
-        size_info.accelerationStructureSize,
-        vk::AccelerationStructureTypeKHR::eTopLevel,
-        {}
-    );
-    as.tlas = vkm(devices[i], devices[i].dev.createAccelerationStructureKHR(create_info));
-    tlas_info.dstAccelerationStructure = as.tlas;
-
-    vk::BufferCreateInfo scratch_info(
-        {}, size_info.buildScratchSize,
-        vk::BufferUsageFlagBits::eStorageBuffer|
-        vk::BufferUsageFlagBits::eShaderDeviceAddress,
-        vk::SharingMode::eExclusive
-    );
-
-    as.scratch_buffer = create_buffer_aligned(
-        devices[i], scratch_info, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT,
-        devices[i].as_props.minAccelerationStructureScratchOffsetAlignment
-    );
-    tlas_info.scratchData = as.scratch_buffer.get_address();
+    tlas.emplace(*ctx, total_max_capacity);
 }
 
 scene::scene_buffer::scene_buffer(device_data& dev)

--- a/src/scene.cc
+++ b/src/scene.cc
@@ -208,17 +208,8 @@ std::vector<descriptor_state> scene::get_descriptor_info(device_data* dev, int32
     if(ctx->is_ray_tracing_supported())
         tlas = get_acceleration_structure(dev->index);
 
-    const std::vector<instance>& instances = get_instances();
-    std::vector<vk::DescriptorBufferInfo> dbi_vertex;
-    std::vector<vk::DescriptorBufferInfo> dbi_index;
-    for(size_t i = 0; i < instances.size(); ++i)
-    {
-        const mesh* m = instances[i].m;
-        vk::Buffer vertex_buffer = m->get_vertex_buffer(dev->index);
-        vk::Buffer index_buffer = m->get_index_buffer(dev->index);
-        dbi_vertex.push_back({vertex_buffer, 0, VK_WHOLE_SIZE});
-        dbi_index.push_back({index_buffer, 0, VK_WHOLE_SIZE});
-    }
+    std::vector<vk::DescriptorBufferInfo> dbi_vertex = get_vertex_buffer_bindings(dev->index);
+    std::vector<vk::DescriptorBufferInfo> dbi_index = get_index_buffer_bindings(dev->index);
 
     std::vector<descriptor_state> descriptors = {
         {"scene", {*sb.scene_data, 0, VK_WHOLE_SIZE}},

--- a/src/scene.cc
+++ b/src/scene.cc
@@ -208,13 +208,12 @@ std::vector<descriptor_state> scene::get_descriptor_info(device_data* dev, int32
     if(ctx->is_ray_tracing_supported())
         tlas = get_acceleration_structure(dev->index);
 
-    const std::vector<std::pair<const mesh*, int>>& meshes =
-        get_meshes();
+    const std::vector<instance>& instances = get_instances();
     std::vector<vk::DescriptorBufferInfo> dbi_vertex;
     std::vector<vk::DescriptorBufferInfo> dbi_index;
-    for(size_t i = 0; i < meshes.size(); ++i)
+    for(size_t i = 0; i < instances.size(); ++i)
     {
-        const mesh* m = meshes[i].first;
+        const mesh* m = instances[i].m;
         vk::Buffer vertex_buffer = m->get_vertex_buffer(dev->index);
         vk::Buffer index_buffer = m->get_index_buffer(dev->index);
         dbi_vertex.push_back({vertex_buffer, 0, VK_WHOLE_SIZE});

--- a/src/scene.hh
+++ b/src/scene.hh
@@ -5,6 +5,7 @@
 #include "timer.hh"
 #include "sampler_table.hh"
 #include "descriptor_state.hh"
+#include "acceleration_structure.hh"
 
 namespace tr
 {
@@ -81,7 +82,6 @@ private:
     friend class scene_update_stage;
 
     void init_acceleration_structures();
-    void init_tlas(size_t device_index);
 
     context* ctx;
     std::vector<camera*> cameras;
@@ -116,20 +116,7 @@ private:
     };
     std::vector<scene_buffer> scene_buffers;
 
-    struct acceleration_structure_data
-    {
-        vkm<vk::AccelerationStructureKHR> tlas;
-        vkm<vk::Buffer> tlas_buffer;
-        vkm<vk::Buffer> scratch_buffer;
-        gpu_buffer instance_buffer;
-
-        struct per_frame_data
-        {
-            size_t instance_count;
-        };
-        per_frame_data per_frame[MAX_FRAMES_IN_FLIGHT];
-    };
-    std::vector<acceleration_structure_data> acceleration_structures;
+    std::optional<top_level_acceleration_structure> tlas;
 };
 
 std::vector<uint32_t> get_viewport_reorder_mask(

--- a/src/scene_update_stage.cc
+++ b/src/scene_update_stage.cc
@@ -24,11 +24,11 @@ struct material_buffer
 
 struct instance_buffer
 {
-    uint32_t mesh_id;
     // -1 if not an area light source, otherwise base index to triangle light
     // array.
     int32_t light_base_id;
     int32_t sh_grid_index;
+    uint32_t pad;
     float shadow_terminator_mul;
     pmat4 model;
     pmat4 model_normal;
@@ -188,8 +188,8 @@ scene_update_stage::scene_update_stage(device_data& dev, const options& opt)
     extract_tri_lights(dev, compute_pipeline::params{
         {"shader/extract_tri_lights.comp"},
         {
-            {"vertices", (uint32_t)opt.max_meshes},
-            {"indices", (uint32_t)opt.max_meshes}
+            {"vertices", (uint32_t)opt.max_instances},
+            {"indices", (uint32_t)opt.max_instances}
         },
         1
     }),
@@ -282,7 +282,7 @@ void scene_update_stage::update(uint32_t frame_index)
                 !cur_scene->get_sh_grid(model[3], &index)
             ) cur_scene->get_largest_sh_grid(&index);
             inst.sh_grid_index = index;
-            inst.mesh_id = cur_scene->find_mesh_id(instances[i].m);
+            inst.pad = 0;
             inst.shadow_terminator_mul = 1.0f/(
                 1.0f-0.5f * instances[i].o->get_shadow_terminator_offset()
             );

--- a/src/scene_update_stage.cc
+++ b/src/scene_update_stage.cc
@@ -513,6 +513,20 @@ void scene_update_stage::update(uint32_t frame_index)
 
     if(dev->ctx->is_ray_tracing_supported())
     {
+        bool need_scene_reset = false;
+        cur_scene->light_scene::update_acceleration_structures(
+            dev->index,
+            frame_index,
+            need_scene_reset,
+            command_buffers_outdated
+        );
+        cur_scene->mesh_scene::update_acceleration_structures(
+            dev->index,
+            frame_index,
+            need_scene_reset,
+            command_buffers_outdated
+        );
+
         auto& instance_buffer = cur_scene->tlas->get_instances_buffer(dev->index);
 
         as_instance_count = 0;
@@ -530,19 +544,7 @@ void scene_update_stage::update(uint32_t frame_index)
                 );
             }
         );
-        bool need_scene_reset = false;
-        cur_scene->light_scene::update_acceleration_structures(
-            dev->index,
-            frame_index,
-            need_scene_reset,
-            command_buffers_outdated
-        );
-        cur_scene->mesh_scene::update_acceleration_structures(
-            dev->index,
-            frame_index,
-            need_scene_reset,
-            command_buffers_outdated
-        );
+
         if(as_rebuild == false)
             as_rebuild = need_scene_reset;
 

--- a/src/scene_update_stage.hh
+++ b/src/scene_update_stage.hh
@@ -16,6 +16,7 @@ public:
     {
         uint32_t max_instances = 1024;
         bool gather_emissive_triangles = false;
+        bool pre_transform_vertices = false;
     };
 
     scene_update_stage(device_data& dev, const options& opt);
@@ -31,7 +32,12 @@ private:
         uint32_t frame_index,
         vk::CommandBuffer cb
     );
+
     void record_tri_light_extraction(
+        vk::CommandBuffer cb
+    );
+
+    void record_pre_transform(
         vk::CommandBuffer cb
     );
 
@@ -44,6 +50,7 @@ private:
     std::vector<uint8_t> old_camera_data;
 
     compute_pipeline extract_tri_lights;
+    compute_pipeline pre_transform;
 
     options opt;
     timer stage_timer;

--- a/src/scene_update_stage.hh
+++ b/src/scene_update_stage.hh
@@ -42,6 +42,7 @@ private:
     );
 
     bool as_rebuild;
+    size_t as_instance_count;
     bool command_buffers_outdated;
     unsigned force_instance_refresh_frames;
     scene* cur_scene;

--- a/src/scene_update_stage.hh
+++ b/src/scene_update_stage.hh
@@ -14,7 +14,7 @@ class scene_update_stage: public stage
 public:
     struct options
     {
-        uint32_t max_meshes = 1024;
+        uint32_t max_instances = 1024;
         bool gather_emissive_triangles = false;
     };
 

--- a/src/shader_source.hh
+++ b/src/shader_source.hh
@@ -42,7 +42,7 @@ struct shader_sources
 
     struct hit_group
     {
-        vk::RayTracingShaderGroupTypeKHR type = 
+        vk::RayTracingShaderGroupTypeKHR type =
             vk::RayTracingShaderGroupTypeKHR::eTrianglesHitGroup;
         shader_source rchit = {};
         shader_source rahit = {};

--- a/src/skinning_stage.cc
+++ b/src/skinning_stage.cc
@@ -127,10 +127,7 @@ void skinning_stage::set_scene(scene* s)
                 {}, barrier, {}, {}
             );
 
-            // Run BLAS updates
-            for(uint32_t i = 0; i < skinned_models.size(); ++i)
-                for(auto& vg: *skinned_models[i])
-                    vg.m->update_blas(cb, dev->index);
+            cur_scene->refresh_dynamic_acceleration_structures(dev->index, i, cb);
         }
 
         stage_timer.end(cb, i);

--- a/src/skinning_stage.cc
+++ b/src/skinning_stage.cc
@@ -17,17 +17,17 @@ struct push_constants
 namespace tr
 {
 
-skinning_stage::skinning_stage(device_data& dev, uint32_t max_meshes)
+skinning_stage::skinning_stage(device_data& dev, uint32_t max_instances)
 :   stage(dev),
     comp(dev, {{"shader/skinning.comp"}, {
-        {"source_data", max_meshes},
-        {"skin_data", max_meshes},
-        {"destination_data", max_meshes},
-        {"joint_data", max_meshes}
+        {"source_data", max_instances},
+        {"skin_data", max_instances},
+        {"destination_data", max_instances},
+        {"joint_data", max_instances}
     }}),
     cur_scene(nullptr),
     stage_timer(dev, "skinning"),
-    max_meshes(max_meshes)
+    max_instances(max_instances)
 {
 }
 
@@ -67,10 +67,10 @@ void skinning_stage::set_scene(scene* s)
     clear_commands();
 
     comp.update_descriptor_set({
-        {"source_data", max_meshes},
-        {"destination_data", max_meshes},
-        {"skin_data", max_meshes},
-        {"joint_data", max_meshes}
+        {"source_data", max_instances},
+        {"destination_data", max_instances},
+        {"skin_data", max_instances},
+        {"joint_data", max_instances}
     });
 
     for(uint32_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)

--- a/src/skinning_stage.hh
+++ b/src/skinning_stage.hh
@@ -15,7 +15,7 @@ class scene;
 class skinning_stage: public stage
 {
 public:
-    skinning_stage(device_data& dev, uint32_t max_meshes);
+    skinning_stage(device_data& dev, uint32_t max_instances);
 
     void set_scene(scene* s);
     scene* get_scene();
@@ -26,7 +26,7 @@ private:
     compute_pipeline comp;
     scene* cur_scene;
     timer stage_timer;
-    uint32_t max_meshes;
+    uint32_t max_instances;
 };
 
 }

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -371,7 +371,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
     }
 
     scene_update_stage::options scene_options;
-    scene_options.max_meshes = s.get_mesh_count();
+    scene_options.max_instances = s.get_instance_count();
     scene_options.gather_emissive_triangles = has_tri_lights && opt.sample_emissive_triangles > 0;
 
     taa_stage::options taa;
@@ -379,7 +379,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
 
     rt_camera_stage::options rc_opt;
     rc_opt.projection = s.get_camera()->get_projection_type();
-    rc_opt.max_meshes = s.get_mesh_count();
+    rc_opt.max_instances = s.get_instance_count();
     rc_opt.max_samplers = s.get_sampler_count();
     rc_opt.min_ray_dist = opt.min_ray_dist;
     rc_opt.max_ray_depth = opt.max_ray_depth;
@@ -556,7 +556,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
                 rr_opt.pcss_samples = min(opt.pcss, 64);
                 rr_opt.pcss_minimum_radius = opt.pcss_minimum_radius;
                 rr_opt.z_pre_pass = opt.use_z_pre_pass;
-                rr_opt.max_skinned_meshes = s.get_mesh_count();
+                rr_opt.max_skinned_meshes = s.get_instance_count();
                 rr_opt.scene_options = scene_options;
                 return new raster_renderer(ctx, rr_opt);
             }
@@ -604,7 +604,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
                 dr_opt.sh.indirect_clamping = opt.indirect_clamping;
                 dr_opt.sh.regularization_gamma = opt.regularization;
                 dr_opt.sh.sampling_weights = sampling_weights;
-                dr_opt.max_skinned_meshes = s.get_mesh_count();
+                dr_opt.max_skinned_meshes = s.get_instance_count();
                 dr_opt.port_number = opt.port;
                 //dr_opt.scene_options = scene_options;
                 return new dshgi_server(ctx, dr_opt);
@@ -680,7 +680,10 @@ void show_stats(scene_data& sd, options& opt)
 
     std::cout << "\nScene statistics: \n";
 
-    std::cout << "Number of meshes = " << sd.s->get_mesh_count() << std::endl;
+    std::set<const mesh*> meshes;
+    for(const mesh_scene::instance& inst: sd.s->get_instances())
+        meshes.insert(inst.m);
+    std::cout << "Number of unique meshes = " << meshes.size() << std::endl;
     std::cout << "Number of mesh instances = " << sd.s->get_instance_count() << std::endl;
 
     //Calculating the number of triangles and dynamic objects

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -373,6 +373,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
     scene_update_stage::options scene_options;
     scene_options.max_instances = s.get_instance_count();
     scene_options.gather_emissive_triangles = has_tri_lights && opt.sample_emissive_triangles > 0;
+    scene_options.pre_transform_vertices = opt.pre_transform_vertices;
 
     taa_stage::options taa;
     taa.blending_ratio = 1.0f - 1.0f/opt.taa.sequence_length;
@@ -391,6 +392,7 @@ renderer* create_renderer(context& ctx, options& opt, scene& s)
     rc_opt.rng_seed = opt.rng_seed;
     rc_opt.local_sampler = opt.sampler;
     rc_opt.transparent_background = opt.transparent_background;
+    rc_opt.pre_transformed_vertices = opt.pre_transform_vertices;
 
     light_sampling_weights sampling_weights;
     sampling_weights.point_lights = has_point_lights ? opt.sample_point_lights : 0.0f;

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -211,6 +211,7 @@ scene_data load_scenes(context& ctx, const options& opt)
     };
     s.s->set_environment_map(s.sky.get());
     s.s->set_ambient(opt.ambient);
+    s.s->set_blas_strategy(opt.as_strategy);
     for(scene_graph& sg: s.scenes)
     {
         sg.to_scene(*s.s);
@@ -687,6 +688,7 @@ void show_stats(scene_data& sd, options& opt)
         meshes.insert(inst.m);
     std::cout << "Number of unique meshes = " << meshes.size() << std::endl;
     std::cout << "Number of mesh instances = " << sd.s->get_instance_count() << std::endl;
+    std::cout << "Number of BLASes (depends on settings) = " << sd.s->get_blas_group_count() << std::endl;
 
     //Calculating the number of triangles and dynamic objects
     uint32_t triangle_count = 0;
@@ -794,6 +796,7 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
             {
                 s.set_shadow_map_renderer(nullptr);
                 s.set_sh_grid_textures(nullptr);
+                s.set_blas_strategy(opt.as_strategy);
                 s.set_camera_jitter(get_camera_jitter_sequence(opt.taa.sequence_length, ctx.get_size()));
                 rr.reset(create_renderer(ctx, opt, s));
                 rr->set_scene(&s);


### PR DESCRIPTION
Previously, Tauray was dealing with BLASes in a really stupid way; it was making one BLAS per material per model. This works fine in small-scale scenes with few materials, like the test scene and Sponza, but starts getting slow in larger scenes like the Bistro scene from ORCA. With this PR, there's two new features for improving raycasting performance:

**Pre-transformed vertices (`--pre-transform-vertices`):**
-----------------------------------------------------------------------------------
This switch makes Tauray pre-calculate all vertices of the scene into a buffer, so that matrices need not be read and multiplied when fetching ray intersection data. Of course, this costs some extra memory. Benefits start being meaningful when the number of bounces gets very high, so I'm not enabling this one by default.

**BLAS assignment strategies (`--as-strategy`)**
-----------------------------------------------------------------------
This option allows adjusting how geometries are divided into BLASes. More in one BLAS leads to better raycasting performance, but generally makes animation updates more difficult. There's four options:

1. `per-material` [old behaviour]
    * Assigns one BLAS per material per model
    * Worst performance
    * Technically lowest memory usage due to better ability to re-use BLASes between models
2. `per-model`
    * Assigns one BLAS per model
    * In practice, memory usage is similar to `per-material`
    * But performance is better
3. `static-merged-dynamic-per-model` [new default]
    * Merges all non-animated objects into one BLAS, while animated objects get one BLAS per model
    * Trade-off for fast traces for most of the scene and fast updates for animated objects
4. `all-merged`
    * Merges all objects into one BLAS
    * Maximum ray-casting performance, but worst memory usage and worst update times (requires full rebuilds if any object ever moves) 
 
Due to our overly-synchronizing approach to compacting BLASes, using strategies 2-4 can also speed up loading time as they reduce the number of compactions that are performed.