### PR TITLE
Add new logging functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ function(add_openxr)
 endfunction()
 add_openxr()
 
+
+set(TAURAY_PROJECT_ROOT "${CMAKE_CURRENT_SOURCE_DIR}")
+string(LENGTH "${TAURAY_PROJECT_ROOT}/" TAURAY_PROJECT_ROOT_PATH_SIZE)
+add_compile_definitions("TAURAY_PROJECT_ROOT_PATH_SIZE=${TAURAY_PROJECT_ROOT_PATH_SIZE}")
+
 add_subdirectory(external/fuchsia_radix_sort)
 
 find_package(SDL2 REQUIRED)
@@ -98,6 +103,7 @@ add_library(tauray-core STATIC
   src/light.cc
   src/light_scene.cc
   src/load_balancer.cc
+  src/log.cc
   src/looking_glass.cc
   src/looking_glass_composition_stage.cc
   src/material.cc

--- a/src/context.cc
+++ b/src/context.cc
@@ -292,7 +292,7 @@ void context::init_vulkan(PFN_vkGetInstanceProcAddr getInstanceProcAddr)
             if(found) ++it;
             else
             {
-                TR_ERR("Unable to find validation layer ", *it, ", skipping.");
+                TR_WARN("Unable to find validation layer ", *it, ", skipping.");
                 validation_layers.erase(it);
             }
         }
@@ -527,7 +527,7 @@ void context::init_devices()
             has_extensions(required_device_extensions, available_extensions) &&
             dev_data.has_graphics && dev_data.has_compute
         ){
-            TR_ERR("Using device: ", props.deviceName);
+            TR_LOG("Using device: ", props.deviceName);
 
             float priority = 1.0f;
             std::vector<vk::DeviceQueueCreateInfo> queue_infos = {

--- a/src/context.cc
+++ b/src/context.cc
@@ -1,6 +1,7 @@
 #include "context.hh"
 #include "placeholders.hh"
 #include "misc.hh"
+#include "log.hh"
 #include "radix_sort/radix_sort_vk.h"
 #include <iostream>
 
@@ -21,7 +22,7 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(
     (void)severity;
     (void)type;
     (void)pUserData;
-    std::cerr << data->pMessage << std::endl;
+    TR_ERR(data->pMessage);
 
     // Handy assert for debugging where validation errors happen
     //assert(false);
@@ -291,8 +292,7 @@ void context::init_vulkan(PFN_vkGetInstanceProcAddr getInstanceProcAddr)
             if(found) ++it;
             else
             {
-                std::cerr << "Unable to find validation layer " << *it
-                    << ", skipping.\n";
+                TR_ERR("Unable to find validation layer ", *it, ", skipping.");
                 validation_layers.erase(it);
             }
         }
@@ -527,9 +527,7 @@ void context::init_devices()
             has_extensions(required_device_extensions, available_extensions) &&
             dev_data.has_graphics && dev_data.has_compute
         ){
-            // TODO: come up with a better way to not have these if piping
-            // trace output to file
-            std::cerr << "Using device: " << props.deviceName << std::endl;
+            TR_ERR("Using device: ", props.deviceName);
 
             float priority = 1.0f;
             std::vector<vk::DeviceQueueCreateInfo> queue_infos = {

--- a/src/dshgi_server.cc
+++ b/src/dshgi_server.cc
@@ -1,6 +1,7 @@
 #include "dshgi_server.hh"
 #include "sh_grid.hh"
 #include "misc.hh"
+#include "log.hh"
 #include <thread>
 #include <iostream>
 #include <czmq.h>
@@ -186,7 +187,7 @@ void dshgi_server::sender_worker(dshgi_server* s)
             frame = zmsg_next(msg);
             if(tag != 0) s->subscriber_count++;
             else s->subscriber_count--;
-            std::cout << "Client count: " << s->subscriber_count << std::endl;
+            TR_LOG("Client count: ", s->subscriber_count);
             zmsg_destroy(&msg);
         }
     };

--- a/src/gltf.cc
+++ b/src/gltf.cc
@@ -1,5 +1,6 @@
 #include "gltf.hh"
 #include "scene.hh"
+#include "log.hh"
 #define TINYGLTF_NO_STB_IMAGE_WRITE
 #include "tiny_gltf.h"
 #include "stb_image.h"
@@ -522,6 +523,7 @@ scene_graph load_gltf(
     bool force_single_sided,
     bool force_double_sided
 ){
+    TR_LOG("Started loading glTF scene from ", path);
     scene_graph md;
 
     std::string err, warn;
@@ -702,11 +704,12 @@ scene_graph load_gltf(
             bool generate_tangents = false;
             if(vert_tangent.size() == 0 && primitive_material.normal_tex.first)
             {
-                std::cerr
-                    << path << ": " << tg_mesh.name
-                    << " uses a normal map but is missing tangent data. Please "
-                    << "export the asset with [Geometry > Tangents] ticked in "
-                    << "Blender." << std::endl;
+                TR_ERR(
+                    path, ": ", tg_mesh.name,
+                    " uses a normal map but is missing tangent data. Please "
+                    "export the asset with [Geometry > Tangents] ticked in "
+                    "Blender."
+                );
                 generate_tangents = true;
             }
 
@@ -801,6 +804,7 @@ scene_graph load_gltf(
         md.animation_models.emplace_back(animation_model);
     }
 
+    TR_LOG("Finished loading glTF scene", path);
     return md;
 }
 

--- a/src/gltf.cc
+++ b/src/gltf.cc
@@ -704,7 +704,7 @@ scene_graph load_gltf(
             bool generate_tangents = false;
             if(vert_tangent.size() == 0 && primitive_material.normal_tex.first)
             {
-                TR_ERR(
+                TR_WARN(
                     path, ": ", tg_mesh.name,
                     " uses a normal map but is missing tangent data. Please "
                     "export the asset with [Geometry > Tangents] ticked in "

--- a/src/headless.cc
+++ b/src/headless.cc
@@ -1,5 +1,6 @@
 #include "headless.hh"
 #include "misc.hh"
+#include "log.hh"
 #include "tinyexr.h"
 #include "stb_image_write.h"
 #include <iostream>
@@ -317,14 +318,16 @@ void headless::save_image(uint32_t swapchain_index)
         if(!opt.skip_nan_check)
         {
             for(size_t j = 0; j < image_pixels; ++j)
+            {
                 if(any(isnan(vec4(
                     mem[j*4+0],
                     mem[j*4+1],
                     mem[j*4+2],
                     mem[j*4+3]
-                ))))
-                    std::cout << "NaN pixel at: "
-                        << (j%opt.size.x) << ", " << (j/opt.size.x) << std::endl;
+                )))){
+                    TR_LOG("NaN pixel at: ", (j%opt.size.x), ", ", (j/opt.size.x));
+                }
+            }
         }
 
         if(opt.output_file_type == headless::EXR)
@@ -405,7 +408,7 @@ void headless::save_image(uint32_t swapchain_index)
 
                 {
                     std::lock_guard<std::mutex> lock(save_workers_mutex);
-                    std::cout << "Saved " << filename << std::endl;
+                    TR_LOG("Saved ", filename);
                     w->finished = true;
                 }
                 save_workers_cv.notify_one();
@@ -438,7 +441,7 @@ void headless::save_image(uint32_t swapchain_index)
 
                 {
                     std::lock_guard<std::mutex> lock(save_workers_mutex);
-                    std::cout << "Saved " << filename << std::endl;
+                    TR_LOG("Saved ", filename);
                     w->finished = true;
                 }
                 save_workers_cv.notify_one();
@@ -466,7 +469,7 @@ void headless::save_image(uint32_t swapchain_index)
 
                 {
                     std::lock_guard<std::mutex> lock(save_workers_mutex);
-                    std::cout << "Saved " << filename << std::endl;
+                    TR_LOG("Saved ", filename);
                     w->finished = true;
                 }
                 save_workers_cv.notify_one();

--- a/src/log.cc
+++ b/src/log.cc
@@ -3,13 +3,41 @@
 namespace tr
 {
 
-bool enabled_log_types[4] = {true, true, true, true};
-std::ostream* log_output_streams[4] = {
+bool enabled_log_types[5] = {true, true, true, true, true};
+std::ostream* log_output_streams[5] = {
     &std::cout,
+    &std::cerr,
     &std::cerr,
     &std::cout,
     &std::cout
 };
+
+void apply_color(log_type type, std::ostream& os)
+{
+#ifdef __unix__
+    if(&os != &std::cout && &os != &std::cerr)
+        return;
+
+    switch(type)
+    {
+    case log_type::GENERAL:
+        os << "\x1b[0;39m";
+        break;
+    case log_type::ERROR:
+        os << "\x1b[0;31m";
+        break;
+    case log_type::WARNING:
+        os << "\x1b[0;33m";
+        break;
+    case log_type::DEBUG:
+        os << "\x1b[0;32m";
+        break;
+    case log_type::TIMING:
+        os << "\x1b[0;94m";
+        break;
+    }
+#endif
+}
 
 std::chrono::system_clock::time_point get_initial_time()
 {

--- a/src/log.cc
+++ b/src/log.cc
@@ -1,0 +1,21 @@
+#include "log.hh"
+
+namespace tr
+{
+
+bool enabled_log_types[4] = {true, true, true, true};
+std::ostream* log_output_streams[4] = {
+    &std::cout,
+    &std::cerr,
+    &std::cout,
+    &std::cout
+};
+
+std::chrono::system_clock::time_point get_initial_time()
+{
+    static std::chrono::system_clock::time_point initial =
+        std::chrono::system_clock::now();
+    return initial;
+}
+
+}

--- a/src/log.hh
+++ b/src/log.hh
@@ -21,6 +21,7 @@
 
 #define TR_LOG(...) tr::log_message(tr::log_type::GENERAL, __LINE__, __FILENAME__, __VA_ARGS__)
 #define TR_ERR(...) tr::log_message(tr::log_type::ERROR, __LINE__, __FILENAME__, __VA_ARGS__)
+#define TR_WARN(...) tr::log_message(tr::log_type::WARNING, __LINE__, __FILENAME__, __VA_ARGS__)
 #define TR_TIME(...) tr::log_message(tr::log_type::TIMING, __LINE__, __FILENAME__, __VA_ARGS__)
 
 namespace tr
@@ -53,12 +54,15 @@ enum class log_type: uint32_t
 {
     GENERAL = 0,
     ERROR,
+    WARNING,
     DEBUG,
     TIMING
 };
 
-extern bool enabled_log_types[4];
-extern std::ostream* log_output_streams[4];
+extern bool enabled_log_types[5];
+extern std::ostream* log_output_streams[5];
+
+void apply_color(log_type type, std::ostream& os);
 
 template<typename... Args>
 void log_message(
@@ -75,6 +79,7 @@ void log_message(
 
         std::ostream& o = *log_output_streams[(uint32_t)type];
 
+        apply_color(type, o);
         if(type != log_type::TIMING)
         {
             o << "[" << std::fixed << std::setprecision(3) <<
@@ -84,6 +89,7 @@ void log_message(
                 << "](" << file << ":" << line << ") ";
         }
         o << make_string(rest...) << std::endl;
+        apply_color(log_type::GENERAL, o);
     }
 }
 

--- a/src/log.hh
+++ b/src/log.hh
@@ -1,0 +1,92 @@
+// Adapted from CC0 code from https://gist.github.com/juliusikkala/fc9c082d33488bdd3b03285463b998f3
+#ifndef LOG_HH
+#define LOG_HH
+#include "math.hh"
+#include <string>
+#include <chrono>
+#include <iostream>
+#include <iomanip>
+
+#ifndef TAURAY_PROJECT_ROOT_PATH_SIZE
+#define TAURAY_PROJECT_ROOT_PATH_SIZE 0
+#endif
+
+#define __FILENAME__ ((const char*)((uintptr_t)__FILE__ + TAURAY_PROJECT_ROOT_PATH_SIZE))
+
+#ifdef PROJECT_DEBUG
+#define TR_DBG(...) tr::log_message(tr::log_type::DEBUG __LINE__, __FILENAME__, __VA_ARGS__)
+#else
+#define TR_DBG(...)
+#endif
+
+#define TR_LOG(...) tr::log_message(tr::log_type::GENERAL, __LINE__, __FILENAME__, __VA_ARGS__)
+#define TR_ERR(...) tr::log_message(tr::log_type::ERROR, __LINE__, __FILENAME__, __VA_ARGS__)
+#define TR_TIME(...) tr::log_message(tr::log_type::TIMING, __LINE__, __FILENAME__, __VA_ARGS__)
+
+namespace tr
+{
+
+std::chrono::system_clock::time_point get_initial_time();
+
+template<typename T>
+std::string to_string(const T& t) { return std::to_string(t); }
+inline std::string to_string(const char* t) { return t; }
+inline std::string to_string(const std::string& t) { return t; }
+inline std::string to_string(const std::string_view& t) { return std::string(t.begin(), t.end()); }
+
+template<glm::length_t L, typename T, glm::qualifier Q>
+inline std::string to_string(const glm::vec<L, T, Q>& t) { return glm::to_string(t); }
+
+template<glm::length_t C, glm::length_t R, typename T, glm::qualifier Q>
+inline std::string to_string(const glm::mat<C, R, T, Q>& t) { return glm::to_string(t); }
+
+template<typename T>
+std::string make_string(const T& t) { return to_string(t); }
+
+template<typename T, typename... Args>
+std::string make_string(
+    const T& t,
+    const Args&... rest
+){ return to_string(t) + make_string(rest...); }
+
+enum class log_type: uint32_t
+{
+    GENERAL = 0,
+    ERROR,
+    DEBUG,
+    TIMING
+};
+
+extern bool enabled_log_types[4];
+extern std::ostream* log_output_streams[4];
+
+template<typename... Args>
+void log_message(
+    log_type type,
+    int line,
+    const char* file,
+    const Args&... rest
+){
+    if(enabled_log_types[(uint32_t)type])
+    {
+        std::chrono::system_clock::time_point now =
+            std::chrono::system_clock::now();
+        std::chrono::system_clock::duration d = now - get_initial_time();
+
+        std::ostream& o = *log_output_streams[(uint32_t)type];
+
+        if(type != log_type::TIMING)
+        {
+            o << "[" << std::fixed << std::setprecision(3) <<
+                std::chrono::duration_cast<
+                    std::chrono::milliseconds
+                >(d).count()/1000.0
+                << "](" << file << ":" << line << ") ";
+        }
+        o << make_string(rest...) << std::endl;
+    }
+}
+
+}
+
+#endif

--- a/src/looking_glass.cc
+++ b/src/looking_glass.cc
@@ -1,5 +1,6 @@
 #include "looking_glass.hh"
 #include "misc.hh"
+#include "log.hh"
 #include "camera.hh"
 #include <iostream>
 #include <nng/nng.h>
@@ -204,30 +205,25 @@ void looking_glass::get_lkg_metadata()
     nng_dialer_close(dialer);
     nng_close(sock);
 
-    std::cout
-        << "Using " << metadata.hardware_id << " ("
-        << metadata.hardware_version << ")" << std::endl;
+    TR_LOG("Using ", metadata.hardware_id, " (", metadata.hardware_version, ")");
 
-    /*
-    std::cout
-        << "dpi: " << metadata.dpi << "\n"
-        << "center: " << metadata.center << "\n"
-        << "pitch: " << metadata.pitch << "\n"
-        << "corrected_pitch: " << metadata.corrected_pitch << "\n"
-        << "size.x: " << metadata.size.x << "\n"
-        << "size.y: " << metadata.size.y << "\n"
-        << "slope: " << metadata.slope << "\n"
-        << "tilt: " << metadata.tilt << "\n"
-        << "vertical_angle: " << metadata.vertical_angle << "\n"
-        << "view_cone: " << metadata.view_cone << "\n"
-        << "quilt_aspect: " << metadata.quilt_aspect << "\n"
-        << "quilt_size.x: " << metadata.quilt_size.x << "\n"
-        << "quilt_size.y: " << metadata.quilt_size.y << "\n"
-        << "tile_count.x: " << metadata.tile_count.x << "\n"
-        << "tile_count.y: " << metadata.tile_count.y << "\n"
-        << "window_coords.x: " << metadata.window_coords.x << "\n"
-        << "window_coords.y: " << metadata.window_coords.y << "\n";
-        */
+    TR_DBG("dpi: ", metadata.dpi);
+    TR_DBG("center: ", metadata.center);
+    TR_DBG("pitch: ", metadata.pitch);
+    TR_DBG("corrected_pitch: ", metadata.corrected_pitch);
+    TR_DBG("size.x: ", metadata.size.x);
+    TR_DBG("size.y: ", metadata.size.y);
+    TR_DBG("slope: ", metadata.slope);
+    TR_DBG("tilt: ", metadata.tilt);
+    TR_DBG("vertical_angle: ", metadata.vertical_angle);
+    TR_DBG("view_cone: ", metadata.view_cone);
+    TR_DBG("quilt_aspect: ", metadata.quilt_aspect);
+    TR_DBG("quilt_size.x: ", metadata.quilt_size.x);
+    TR_DBG("quilt_size.y: ", metadata.quilt_size.y);
+    TR_DBG("tile_count.x: ", metadata.tile_count.x);
+    TR_DBG("tile_count.y: ", metadata.tile_count.y);
+    TR_DBG("window_coords.x: ", metadata.window_coords.x);
+    TR_DBG("window_coords.y: ", metadata.window_coords.y);
 
     if(error.size() != 0)
         throw std::runtime_error(error);
@@ -360,10 +356,11 @@ void looking_glass::init_swapchain()
         }
     }
     if(!found_format)
-        std::cerr <<
+        TR_ERR(
             "Could not find any suitable swap chain format!"
             "Using the first available format instead, results may look "
-            "incorrect.\n";
+            "incorrect."
+        );
     image_format = swapchain_format.format;
     expected_image_layout = vk::ImageLayout::eGeneral;
 
@@ -409,9 +406,10 @@ void looking_glass::init_swapchain()
         }
     }
     if(!found_mode)
-        std::cerr <<
+        TR_ERR(
             "Could not find desired present mode, falling back to first "
-            "available mode.\n";
+            "available mode."
+        );
 
     // Find the size that matches our looking_glass size
     vk::SurfaceCapabilitiesKHR caps =
@@ -561,7 +559,7 @@ void looking_glass::init_render_target()
         ));
     } catch(std::runtime_error& err)
     {
-        printf("%s\n", err.what());
+        TR_ERR(err.what());
         std::abort();
     }
 }

--- a/src/looking_glass.cc
+++ b/src/looking_glass.cc
@@ -356,7 +356,7 @@ void looking_glass::init_swapchain()
         }
     }
     if(!found_format)
-        TR_ERR(
+        TR_WARN(
             "Could not find any suitable swap chain format!"
             "Using the first available format instead, results may look "
             "incorrect."
@@ -406,7 +406,7 @@ void looking_glass::init_swapchain()
         }
     }
     if(!found_mode)
-        TR_ERR(
+        TR_WARN(
             "Could not find desired present mode, falling back to first "
             "available mode."
         );

--- a/src/main.cc
+++ b/src/main.cc
@@ -13,7 +13,10 @@ int main(int, char** argv) try
     std::optional<std::ofstream> timing_output_file;
 
     if(opt.silent)
+    {
         tr::enabled_log_types[(uint32_t)tr::log_type::GENERAL] = false;
+        tr::enabled_log_types[(uint32_t)tr::log_type::WARNING] = false;
+    }
 
     if(opt.timing_output.size() != 0)
     {

--- a/src/main.cc
+++ b/src/main.cc
@@ -7,6 +7,20 @@ int main(int, char** argv) try
 
     tr::options opt;
     tr::parse_command_line_options(argv, opt);
+
+    // Initialize log timer.
+    tr::get_initial_time();
+    std::optional<std::ofstream> timing_output_file;
+
+    if(opt.silent)
+        tr::enabled_log_types[(uint32_t)tr::log_type::GENERAL] = false;
+
+    if(opt.timing_output.size() != 0)
+    {
+        timing_output_file.emplace(opt.timing_output, std::ios::binary|std::ios::trunc);
+        tr::log_output_streams[(uint32_t)tr::log_type::TIMING] = &timing_output_file.value();
+    }
+
     std::unique_ptr<tr::context> ctx(tr::create_context(opt));
 
     tr::scene_data sd = tr::load_scenes(*ctx, opt);
@@ -17,8 +31,8 @@ int main(int, char** argv) try
 }
 catch (std::runtime_error& e)
 {
+    // Can't use TR_ERR here, because the logger may not yet be initialized or
+    // it's output file may already be closed.
     if (strlen(e.what())) std::cerr << e.what() << "\n" << std::endl;
-
-    tr::print_help(argv[0]);
     return 1;
 }

--- a/src/mesh_scene.cc
+++ b/src/mesh_scene.cc
@@ -1,5 +1,6 @@
 #include "mesh_scene.hh"
 #include "misc.hh"
+#include "log.hh"
 #include <unordered_set>
 
 namespace tr
@@ -410,6 +411,7 @@ void mesh_scene::ensure_blas()
 {
     if(!ctx->is_ray_tracing_supported())
         return;
+    bool built_one = false;
     // Goes through all groups and ensures they have valid BLASes.
     size_t offset = 0;
     std::vector<bottom_level_acceleration_structure::entry> entries;
@@ -421,6 +423,11 @@ void mesh_scene::ensure_blas()
             offset += group.size;
             continue;
         }
+
+        if(!built_one)
+            TR_LOG("Building acceleration structures");
+
+        built_one = true;
 
         entries.clear();
         bool double_sided = false;
@@ -445,6 +452,8 @@ void mesh_scene::ensure_blas()
             )
         );
     }
+    if(built_one)
+        TR_LOG("Finished building acceleration structures");
 }
 
 void mesh_scene::assign_group_cache(

--- a/src/misc.cc
+++ b/src/misc.cc
@@ -609,7 +609,7 @@ void profile_tick()
 
 void profile_tock(const char* message)
 {
-    auto begin = profile_begin.back(); 
+    auto begin = profile_begin.back();
     profile_begin.pop_back();
     auto profile_end = std::chrono::high_resolution_clock::now();
     auto duration = profile_end - begin;

--- a/src/misc.hh
+++ b/src/misc.hh
@@ -8,6 +8,12 @@ namespace tr
 struct device_data;
 class context;
 
+template<typename T, size_t count>
+inline std::string to_string(const vk::ArrayWrapper1D<T, count>& vkstring)
+{
+    return vkstring.data();
+}
+
 // These are for one-off command buffers.
 vk::CommandBuffer begin_command_buffer(device_data& d);
 void end_command_buffer(device_data& d, vk::CommandBuffer cb);

--- a/src/openxr.cc
+++ b/src/openxr.cc
@@ -609,7 +609,7 @@ void openxr::init_xr_swapchain()
         }
     }
     if(!found_format)
-        TR_ERR(
+        TR_WARN(
             "Could not find any suitable swap chain format for XR!"
             "Using the first available format instead, results may look "
             "incorrect."
@@ -750,7 +750,7 @@ void openxr::init_window_swapchain()
         }
     }
     if(!found_format)
-        TR_ERR("Could not find any suitable swap chain format for preview window!");
+        TR_WARN("Could not find any suitable swap chain format for preview window!");
 
     window_image_format = swapchain_format.format;
 
@@ -769,7 +769,7 @@ void openxr::init_window_swapchain()
         found_mode = true;
     }
     if(!found_mode)
-        TR_ERR(
+        TR_WARN(
             "Could not find desired present mode, falling back to first "
             "available mode."
         );

--- a/src/openxr.cc
+++ b/src/openxr.cc
@@ -1,6 +1,7 @@
 #include "openxr.hh"
 #include "camera.hh"
 #include "misc.hh"
+#include "log.hh"
 #include <iostream>
 #include <thread>
 
@@ -58,7 +59,7 @@ XRAPI_ATTR XrBool32 XRAPI_CALL debug_callback(
     (void)severity;
     (void)type;
     (void)pUserData;
-    std::cerr << data->message << std::endl;
+    TR_ERR(data->message);
 
     // Handy assert for debugging where validation errors happen
     //assert(false);
@@ -432,7 +433,7 @@ void openxr::init_xr()
     };
     xrGetInstanceProperties(xr_instance, &xr_instance_props);
 
-    std::cout << "OpenXR runtime: " << xr_instance_props.runtimeName << std::endl;
+    TR_LOG("OpenXR runtime: ", xr_instance_props.runtimeName);
 
     XrSystemGetInfo system_info {
         XR_TYPE_SYSTEM_GET_INFO,
@@ -446,7 +447,7 @@ void openxr::init_xr()
     system_props.next = nullptr;
     xrGetSystemProperties(xr_instance, system_id, &system_props);
 
-    std::cout << "OpenXR system: " << system_props.systemName << std::endl;
+    TR_LOG("OpenXR system: ", system_props.systemName);
 
     uint32_t view_config_count = 0;
     xrEnumerateViewConfigurations(xr_instance, system_id, 0, &view_config_count, nullptr);
@@ -608,10 +609,11 @@ void openxr::init_xr_swapchain()
         }
     }
     if(!found_format)
-        std::cerr <<
+        TR_ERR(
             "Could not find any suitable swap chain format for XR!"
             "Using the first available format instead, results may look "
-            "incorrect.\n";
+            "incorrect."
+        );
 
     image_format = vk::Format((VkFormat)swapchain_format);
     expected_image_layout = vk::ImageLayout::eTransferSrcOptimal;
@@ -748,8 +750,7 @@ void openxr::init_window_swapchain()
         }
     }
     if(!found_format)
-        std::cerr <<
-            "Could not find any suitable swap chain format for preview window!\n";
+        TR_ERR("Could not find any suitable swap chain format for preview window!");
 
     window_image_format = swapchain_format.format;
 
@@ -768,9 +769,10 @@ void openxr::init_window_swapchain()
         found_mode = true;
     }
     if(!found_mode)
-        std::cerr <<
+        TR_ERR(
             "Could not find desired present mode, falling back to first "
-            "available mode.\n";
+            "available mode."
+        );
 
     // Find the size that matches our window size
     vk::SurfaceCapabilitiesKHR caps =
@@ -1003,11 +1005,11 @@ bool openxr::poll()
                         view_config
                     };
                     xrBeginSession(xr_session, &begin_info);
-                    std::cout << "XR session begin" << std::endl;
+                    TR_LOG("XR session begin");
                 }
                 else if(state.state == XR_SESSION_STATE_STOPPING)
                 {
-                    std::cout << "XR session end" << std::endl;
+                    TR_LOG("XR session end");
                     xrEndSession(xr_session);
                     return true;
                 }

--- a/src/options.hh
+++ b/src/options.hh
@@ -497,6 +497,14 @@
         {"per-model", blas_strategy::PER_MODEL}, \
         {"static-merged-dynamic-per-model", blas_strategy::STATIC_MERGED_DYNAMIC_PER_MODEL}, \
         {"all-merged", blas_strategy::ALL_MERGED_STATIC} \
+    ) \
+    TR_BOOL_OPT(silent, \
+        "Disables general prints. Errors and timing data is still shown.", \
+        false \
+    ) \
+    TR_STRING_OPT(timing_output, \
+        "Sets the timing data output file. Default is stdout.", \
+        "" \
     )
 //==============================================================================
 // END OF OPTIONS

--- a/src/raster_renderer.cc
+++ b/src/raster_renderer.cc
@@ -1,6 +1,7 @@
 #include "raster_renderer.hh"
 #include "scene.hh"
 #include "misc.hh"
+#include "log.hh"
 #include <iostream>
 
 namespace tr
@@ -74,9 +75,9 @@ void raster_renderer::init_common_resources()
     int fixed_msaa = min((int)next_power_of_two(opt.msaa_samples), max_msaa);
     if(opt.msaa_samples != fixed_msaa)
     {
-        std::cerr << "Sample count " << opt.msaa_samples
-            << " is not available on this platform. Using " << fixed_msaa
-            << " instead." << std::endl;
+        TR_LOG("Sample count ", opt.msaa_samples,
+            " is not available on this platform. Using ", fixed_msaa,
+            " instead.");
         opt.msaa_samples = fixed_msaa;
     }
 

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -984,7 +984,7 @@ void replay_viewer(context& ctx, scene_data& sd, options& opt)
     camera default_cam;
     if(s.get_camera() == nullptr)
     {
-        TR_ERR(
+        TR_WARN(
             "Warning: no camera is defined in the scene, so a default camera "
             "setup is used. You probably do not want this in replay mode."
         );

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -808,7 +808,7 @@ void interactive_viewer(context& ctx, scene_data& sd, options& opt)
             catch(std::runtime_error& err)
             {
                 if(crash_on_exception) throw err;
-                else std::cerr << err.what() << std::endl;
+                else TR_ERR(err.what());
             }
             show_stats(sd, opt);
 
@@ -984,10 +984,10 @@ void replay_viewer(context& ctx, scene_data& sd, options& opt)
     camera default_cam;
     if(s.get_camera() == nullptr)
     {
-        std::cerr
-            << "Warning: no camera is defined in the scene, so a default camera "
-               "setup is used. You probably do not want this in replay mode."
-            << std::endl;
+        TR_ERR(
+            "Warning: no camera is defined in the scene, so a default camera "
+            "setup is used. You probably do not want this in replay mode."
+        );
         default_cam.set_position(vec3(0,0,2));
         default_cam.perspective(90, opt.width/(float)opt.height, 0.1f, 300.0f);
         s.set_camera(&default_cam);
@@ -1128,7 +1128,7 @@ void headless_server(context& ctx, scene_data& sd, options& opt)
 
     // Ensure everything is finished before going to destructors.
     ctx.sync();
-    std::cout << "Server shutting down." << std::endl;
+    TR_LOG("Server shutting down.");
 }
 
 void run(context& ctx, scene_data& sd, options& opt)

--- a/src/tauray.hh
+++ b/src/tauray.hh
@@ -4,6 +4,7 @@
 #include "environment_map.hh"
 #include "scene.hh"
 #include "ply.hh"
+#include "log.hh"
 #include <memory>
 #include <vector>
 

--- a/src/tracing.cc
+++ b/src/tracing.cc
@@ -1,5 +1,6 @@
 #include "tracing.hh"
 #include "context.hh"
+#include "log.hh"
 #include "json.hpp"
 #include <iostream>
 
@@ -229,39 +230,35 @@ const tracing_record::timing_result* tracing_record::find_latest_finished_frame(
 
 void tracing_record::print_simple_trace(const timing_result& res)
 {
-    std::cout << "FRAME " << res.frame_number << ":\n";
+    TR_TIME("FRAME ", res.frame_number, ":");
     for(size_t i = 0; i < res.device_traces.size(); ++i)
     {
         const std::vector<trace_event>& times = res.device_traces[i];
 
-        std::cout << "\tDEVICE " << i << ": ";
         if(times.size() == 0)
-            std::cout << "\n";
+            TR_TIME("\tDEVICE ", i, ": ");
         else
         {
             double delta_ns = times.back().start_ns + times.back().duration_ns - times.front().start_ns;
-            std::cout << delta_ns/1e6 << " ms\n";
+            TR_TIME("\tDEVICE ", i, ": ", delta_ns/1e6, " ms");
         }
 
         for(const trace_event& t: times)
         {
-            std::cout << "\t\t[" << t.name << "] " << t.duration_ns/1e6 << " ms"
-                << "\n";
+            TR_TIME("\t\t[", t.name, "] ", t.duration_ns/1e6, " ms");
         }
     }
 
-    std::cout << "\tHOST: ";
     if(res.host_traces.size() == 0)
-        std::cout << "\n";
+        TR_TIME("\tHOST: ");
     else
     {
         double delta_ns = res.host_traces.back().start_ns + res.host_traces.back().duration_ns - res.host_traces.front().start_ns;
-        std::cout << delta_ns/1e6 << " ms\n";
+        TR_TIME("\tHOST: ", delta_ns/1e6, " ms");
     }
     for(const trace_event& t: res.host_traces)
     {
-        std::cout << "\t\t[" << t.name << "] " << t.duration_ns/1e6 << " ms"
-            << "\n";
+        TR_TIME("\t\t[", t.name, "] ", t.duration_ns/1e6, " ms");
     }
 }
 
@@ -270,7 +267,7 @@ void tracing_record::print_tef_trace(const timing_result& res)
     static bool first_call = true;
     if(first_call)
     {
-        std::cout << "[";
+        TR_TIME("[");
         first_call = false;
     }
     for(const trace_event& t: res.host_traces)
@@ -284,7 +281,7 @@ void tracing_record::print_tef_trace(const timing_result& res)
             {"name", t.name},
             {"args", {"frame", res.frame_number}}
         };
-        std::cout << output.dump(-1, '\t') << ",\n";
+        TR_TIME(output.dump(-1, '\t'), ",");
     }
     const auto& devices = ctx->get_devices();
     for(size_t i = 0; i < res.device_traces.size(); ++i)
@@ -301,7 +298,7 @@ void tracing_record::print_tef_trace(const timing_result& res)
                 {"name", t.name},
                 {"args", {"frame", res.frame_number}}
             };
-            std::cout << output.dump(-1, '\t') << ",\n";
+            TR_TIME(output.dump(-1, '\t'), ",");
         }
     }
 }

--- a/src/window.cc
+++ b/src/window.cc
@@ -129,7 +129,7 @@ void window::init_swapchain()
         }
     }
     if(!found_format)
-        TR_ERR(
+        TR_WARN(
             "Could not find any suitable swap chain format!"
             "Using the first available format instead, results may look "
             "incorrect."
@@ -179,7 +179,7 @@ void window::init_swapchain()
         }
     }
     if(!found_mode)
-        TR_ERR("Could not find desired present mode, falling back to first "
+        TR_WARN("Could not find desired present mode, falling back to first "
             "available mode.");
 
     // Find the size that matches our window size

--- a/src/window.cc
+++ b/src/window.cc
@@ -1,4 +1,5 @@
 #include "window.hh"
+#include "log.hh"
 #include <iostream>
 
 namespace tr
@@ -128,10 +129,11 @@ void window::init_swapchain()
         }
     }
     if(!found_format)
-        std::cerr <<
+        TR_ERR(
             "Could not find any suitable swap chain format!"
             "Using the first available format instead, results may look "
-            "incorrect.\n";
+            "incorrect."
+        );
     image_format = swapchain_format.format;
     expected_image_layout = vk::ImageLayout::ePresentSrcKHR;
 
@@ -177,9 +179,8 @@ void window::init_swapchain()
         }
     }
     if(!found_mode)
-        std::cerr <<
-            "Could not find desired present mode, falling back to first "
-            "available mode.\n";
+        TR_ERR("Could not find desired present mode, falling back to first "
+            "available mode.");
 
     // Find the size that matches our window size
     vk::SurfaceCapabilitiesKHR caps =


### PR DESCRIPTION
Before, logging in Tauray was done in an ad-hoc manner using std::cout and std::cerr directly. This PR adds:

- A method for changing the output streams to something else
- Ability to silence general output
- Make general logging print time since startup as well as source file