### PR TITLE
Make stages always manage their own pipelines

### DIFF
--- a/src/direct_stage.cc
+++ b/src/direct_stage.cc
@@ -97,24 +97,31 @@ direct_stage::direct_stage(
     const gbuffer_target& output_target,
     const options& opt
 ):  rt_camera_stage(
-        dev, output_target,
-        rt_stage::get_common_state(
-            ray_count, uvec4(0,0,output_target.get_size()),
-            direct::load_sources(opt, output_target), opt
-        ),
-        opt,
-        "direct light",
+        dev, output_target, opt, "direct light",
         opt.samples_per_pixel / opt.samples_per_pass
     ),
+    gfx(dev, rt_stage::get_common_state(
+        ray_count, uvec4(0,0,output_target.get_size()),
+        direct::load_sources(opt, output_target), opt
+    )),
     opt(opt)
 {
 }
 
-void direct_stage::record_command_buffer_push_constants(
+void direct_stage::init_scene_resources()
+{
+    rt_camera_stage::init_descriptors(gfx);
+}
+
+void direct_stage::record_command_buffer_pass(
     vk::CommandBuffer cb,
-    uint32_t /*frame_index*/,
-    uint32_t pass_index
+    uint32_t frame_index,
+    uint32_t pass_index,
+    uvec3 expected_dispatch_size
 ){
+    if(pass_index == 0)
+        gfx.bind(cb, frame_index);
+
     scene* cur_scene = get_scene();
     direct::push_constant_buffer control;
 
@@ -138,6 +145,7 @@ void direct_stage::record_command_buffer_push_constants(
     control.antialiasing = opt.film != film_filter::POINT ? 1 : 0;
 
     gfx.push_constants(cb, control);
+    gfx.trace_rays(cb, expected_dispatch_size);
 }
 
 }

--- a/src/direct_stage.hh
+++ b/src/direct_stage.hh
@@ -27,13 +27,16 @@ public:
     );
 
 protected:
-    void record_command_buffer_push_constants(
+    void init_scene_resources() override;
+    void record_command_buffer_pass(
         vk::CommandBuffer cb,
         uint32_t frame_index,
-        uint32_t pass_index
+        uint32_t pass_index,
+        uvec3 expected_dispatch_size
     ) override;
 
 private:
+    gfx_pipeline gfx;
     options opt;
 };
 

--- a/src/feature_stage.hh
+++ b/src/feature_stage.hh
@@ -31,20 +31,24 @@ public:
     };
 
     feature_stage(
-        device_data& dev, 
+        device_data& dev,
         uvec2 ray_count,
         const gbuffer_target& output_target,
         const options& opt
     );
 
 protected:
-    void record_command_buffer_push_constants(
+    void init_scene_resources() override;
+
+    void record_command_buffer_pass(
         vk::CommandBuffer cb,
         uint32_t frame_index,
-        uint32_t pass_index
+        uint32_t pass_index,
+        uvec3 expected_dispatch_size
     ) override;
 
 private:
+    gfx_pipeline gfx;
     options opt;
 };
 

--- a/src/path_tracer_stage.hh
+++ b/src/path_tracer_stage.hh
@@ -37,13 +37,17 @@ public:
     );
 
 protected:
-    void record_command_buffer_push_constants(
+    void init_scene_resources() override;
+
+    void record_command_buffer_pass(
         vk::CommandBuffer cb,
         uint32_t frame_index,
-        uint32_t pass_index
+        uint32_t pass_index,
+        uvec3 expected_dispatch_size
     ) override;
 
 private:
+    gfx_pipeline gfx;
     options opt;
 };
 

--- a/src/rt_camera_stage.hh
+++ b/src/rt_camera_stage.hh
@@ -32,7 +32,6 @@ public:
     rt_camera_stage(
         device_data& dev,
         const gbuffer_target& output_target,
-        const gfx_pipeline::pipeline_state& state,
         const options& opt,
         const std::string& timer_name = "ray tracing",
         unsigned pass_count = 1
@@ -45,16 +44,18 @@ public:
 
 protected:
     void update(uint32_t frame_index) override;
-    void init_scene_resources() override;
     void record_command_buffer(
         vk::CommandBuffer cb, uint32_t frame_index, uint32_t pass_index
     ) override;
     int get_accumulated_samples() const;
 
-    virtual void record_command_buffer_push_constants(
+    void init_descriptors(basic_pipeline& pp);
+
+    virtual void record_command_buffer_pass(
         vk::CommandBuffer cb,
         uint32_t frame_index,
-        uint32_t pass_index
+        uint32_t pass_index,
+        uvec3 expected_dispatch_size
     ) = 0;
 
 private:

--- a/src/rt_stage.cc
+++ b/src/rt_stage.cc
@@ -75,12 +75,10 @@ void rt_stage::get_common_defines(
 
 rt_stage::rt_stage(
     device_data& dev,
-    const gfx_pipeline::pipeline_state& state,
     const options& opt,
     const std::string& timer_name,
     unsigned pass_count
 ):  stage(dev),
-    gfx(dev, state),
     opt(opt),
     pass_count(pass_count),
     rt_timer(dev, timer_name),
@@ -92,7 +90,6 @@ rt_stage::rt_stage(
     sampling_frame_counter_increment(1),
     sample_counter(0)
 {
-    init_resources();
 }
 
 void rt_stage::set_scene(scene* s)
@@ -137,25 +134,23 @@ void rt_stage::update(uint32_t frame_index)
     sample_counter += sampling_frame_counter_increment;
 }
 
-void rt_stage::init_resources()
+void rt_stage::init_scene_resources() {}
+
+void rt_stage::init_descriptors(basic_pipeline& pp)
 {
     // Init descriptor set references to some placeholder value to silence
     // the validation layer (these should never actually be accessed)
-    gfx.update_descriptor_set({
+    pp.update_descriptor_set({
         {"vertices", opt.max_instances},
         {"indices", opt.max_instances},
         {"textures", opt.max_samplers}
     });
     for(size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)
     {
-        gfx.update_descriptor_set({
+        pp.update_descriptor_set({
             {"sampling_data", {*sampling_data, 0, VK_WHOLE_SIZE}}
         }, i);
     }
-}
-
-void rt_stage::init_scene_resources()
-{
 }
 
 unsigned rt_stage::get_pass_count() const

--- a/src/rt_stage.hh
+++ b/src/rt_stage.hh
@@ -54,7 +54,6 @@ public:
 
     rt_stage(
         device_data& dev,
-        const gfx_pipeline::pipeline_state& local_state,
         const options& opt,
         const std::string& timer_name,
         unsigned pass_count = 1
@@ -79,16 +78,13 @@ protected:
         uint32_t frame_index,
         uint32_t pass_index
     ) = 0;
-    virtual void init_scene_resources();
+    virtual void init_scene_resources() = 0;
+    void init_descriptors(basic_pipeline& pp);
     void record_command_buffers();
 
     unsigned get_pass_count() const;
 
-    gfx_pipeline gfx;
-
 private:
-    void init_resources();
-
     options opt;
     unsigned pass_count = 1;
     timer rt_timer;

--- a/src/sh_path_tracer_stage.cc
+++ b/src/sh_path_tracer_stage.cc
@@ -107,18 +107,16 @@ sh_path_tracer_stage::sh_path_tracer_stage(
     texture& output_grid,
     vk::ImageLayout output_layout,
     const options& opt
-):  rt_stage(
-        dev,
-        rt_stage::get_common_state(
-            uvec2(0), uvec4(0), sh_path_tracer::load_sources(opt), opt
-        ),
-        opt, "SH path tracing", 1
-    ),
+):  rt_stage(dev, opt, "SH path tracing", 1),
+    gfx(dev, rt_stage::get_common_state(
+        uvec2(0), uvec4(0), sh_path_tracer::load_sources(opt), opt
+    )),
     opt(opt),
     output_grid(&output_grid),
     output_layout(output_layout),
     grid_data(dev, sizeof(grid_data_buffer), vk::BufferUsageFlagBits::eUniformBuffer)
 {
+    init_descriptors(gfx);
     rt_stage::set_local_sampler_parameters(
         output_grid.get_dimensions(),
         opt.samples_per_probe

--- a/src/sh_path_tracer_stage.hh
+++ b/src/sh_path_tracer_stage.hh
@@ -43,6 +43,8 @@ protected:
         vk::CommandBuffer cb, uint32_t frame_index, uint32_t pass_index
     ) override;
 
+    gfx_pipeline gfx;
+
 private:
     void record_command_buffer_push_constants(
         vk::CommandBuffer cb,

--- a/src/whitted_stage.cc
+++ b/src/whitted_stage.cc
@@ -70,21 +70,29 @@ whitted_stage::whitted_stage(
     const options& opt
 ):  rt_camera_stage(
         dev, output_target,
-        build_state(rt_stage::get_common_state(
-            ray_count, uvec4(0,0,output_target.get_size()),
-            whitted::load_sources(opt), opt
-        ), opt),
         opt
     ),
+    gfx(dev, build_state(rt_stage::get_common_state(
+        ray_count, uvec4(0,0,output_target.get_size()),
+        whitted::load_sources(opt), opt
+    ), opt)),
     opt(opt)
 {
 }
 
-void whitted_stage::record_command_buffer_push_constants(
+void whitted_stage::init_scene_resources()
+{
+    rt_camera_stage::init_descriptors(gfx);
+}
+
+void whitted_stage::record_command_buffer_pass(
     vk::CommandBuffer cb,
-    uint32_t /*frame_index*/,
-    uint32_t /*pass_index*/
+    uint32_t frame_index,
+    uint32_t /*pass_index*/,
+    uvec3 expected_dispatch_size
 ){
+    gfx.bind(cb, frame_index);
+
     scene* cur_scene = get_scene();
     whitted::push_constant_buffer control;
     control.directional_light_count = cur_scene->get_directional_lights().size();
@@ -108,6 +116,7 @@ void whitted_stage::record_command_buffer_push_constants(
     control.min_ray_dist = opt.min_ray_dist;
 
     gfx.push_constants(cb, control);
+    gfx.trace_rays(cb, expected_dispatch_size);
 }
 
 }

--- a/src/whitted_stage.hh
+++ b/src/whitted_stage.hh
@@ -22,13 +22,16 @@ public:
     );
 
 protected:
-    void record_command_buffer_push_constants(
+    void init_scene_resources() override;
+    void record_command_buffer_pass(
         vk::CommandBuffer cb,
         uint32_t frame_index,
-        uint32_t pass_index
+        uint32_t pass_index,
+        uvec3 expected_dispatch_size
     ) override;
 
 private:
+    gfx_pipeline gfx;
     options opt;
 };
 


### PR DESCRIPTION
This is needed so that stages that derive from `rt_camera_stage` can have multiple pipelines.