### PR TITLE
Add optional progress bar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ add_library(tauray-core STATIC
   src/plane.cc
   src/ply.cc
   src/post_processing_renderer.cc
+  src/progress_tracker.cc
   src/radix_sort.cc
   src/raster_stage.cc
   src/raster_renderer.cc

--- a/src/context.cc
+++ b/src/context.cc
@@ -67,7 +67,7 @@ namespace tr
 context::context(const options& opt)
 :   image_array_layers(0), opt(opt), frame_counter(0),
     displayed_frame_counter(0), swapchain_index(0), frame_index(0),
-    is_displaying(true), timing(this)
+    is_displaying(true), timing(this), tracker(this)
 {}
 
 context::~context() {}
@@ -245,6 +245,11 @@ void context::sync()
 tracing_record& context::get_timing()
 {
     return timing;
+}
+
+progress_tracker& context::get_progress_tracker()
+{
+    return tracker;
 }
 
 void context::queue_frame_finish_callback(std::function<void()>&& func)
@@ -735,6 +740,7 @@ void context::deinit_resources()
     frame_finished.clear();
     image_fences.clear();
     timing.deinit();
+    tracker.end();
 }
 
 void context::call_frame_end_actions(uint32_t frame_index)

--- a/src/context.hh
+++ b/src/context.hh
@@ -6,6 +6,7 @@
 #include "dependency.hh"
 #include "render_target.hh"
 #include "tracing.hh"
+#include "progress_tracker.hh"
 #include <set>
 #include <map>
 #include <memory>
@@ -120,6 +121,7 @@ public:
     void sync();
 
     tracing_record& get_timing();
+    progress_tracker& get_progress_tracker();
 
     // You can add functions to be called when the current frame is guaranteed
     // to be finished on the GPU side.
@@ -200,6 +202,7 @@ private:
     std::unique_ptr<placeholders> placeholder_data;
 
     tracing_record timing;
+    progress_tracker tracker;
 
     // Callbacks for the end of each frame.
     std::vector<std::function<void()>> frame_end_actions[MAX_FRAMES_IN_FLIGHT];

--- a/src/options.hh
+++ b/src/options.hh
@@ -11,6 +11,10 @@
     TR_INT_SOPT(height, 'h', "Set viewport height.", 720, 0, INT_MAX) \
     TR_BOOL_SOPT(fullscreen, 'f', "Enable fullscreen mode.") \
     TR_BOOL_SOPT(vsync, 's', "Enable vertical synchronization.") \
+    TR_BOOL_SOPT( \
+        progress, 'p', \
+        "Add a progress bar, useful for long offline renders." \
+    ) \
     TR_BOOL_OPT(hdr, "Try to find an HDR swap chain.", false) \
     TR_BOOL_SOPT(timing, 't', "Print frame times.") \
     TR_SETINT_OPT(devices, \

--- a/src/progress_tracker.cc
+++ b/src/progress_tracker.cc
@@ -1,0 +1,213 @@
+#include "progress_tracker.hh"
+#include "context.hh"
+#include "misc.hh"
+#include <mutex>
+#include <iostream>
+#include <iomanip>
+#include <string>
+
+namespace tr
+{
+
+progress_tracker::progress_tracker(context* ctx)
+: ctx(ctx), running(false)
+{
+
+}
+
+progress_tracker::~progress_tracker()
+{
+    end();
+}
+
+void progress_tracker::begin(options opt)
+{
+    end();
+    running = true;
+    this->opt = opt;
+
+    std::vector<device_data>& devices = ctx->get_devices();
+    tracking_resources.resize(devices.size());
+
+    for(size_t i = 0; i < devices.size(); ++i)
+    {
+        vk::BufferCreateInfo create_info;
+        create_info.size = sizeof(tracking_stamp);
+        create_info.usage =
+            vk::BufferUsageFlagBits::eTransferDst|vk::BufferUsageFlagBits::eTransferSrc;
+        create_info.sharingMode = vk::SharingMode::eExclusive;
+
+        vk::Buffer res;
+        VmaAllocation alloc;
+        VmaAllocationInfo info;
+        VmaAllocationCreateInfo alloc_info = {};
+        alloc_info.usage = VMA_MEMORY_USAGE_AUTO;
+        alloc_info.flags = VMA_ALLOCATION_CREATE_HOST_ACCESS_RANDOM_BIT|VMA_ALLOCATION_CREATE_MAPPED_BIT;
+
+        vmaCreateBuffer(
+            devices[i].allocator, (VkBufferCreateInfo*)&create_info,
+            &alloc_info, reinterpret_cast<VkBuffer*>(&res),
+            &alloc, &info
+        );
+        tracking_resources[i].tracking_data = vkm<vk::Buffer>(devices[i], res, alloc);
+        tracking_resources[i].tracking_data_ptr = (tracking_stamp*)info.pMappedData;
+
+        create_info.size = sizeof(uint32_t) * MAX_FRAMES_IN_FLIGHT;
+        vmaCreateBuffer(
+            devices[i].allocator, (VkBufferCreateInfo*)&create_info,
+            &alloc_info, reinterpret_cast<VkBuffer*>(&res),
+            &alloc, &info
+        );
+        tracking_resources[i].frame_buffer = vkm<vk::Buffer>(devices[i], res, alloc);
+        tracking_resources[i].frame_buffer_ptr = (uint32_t*)info.pMappedData;
+    }
+
+    poll_thread.emplace(poll_worker, this);
+}
+
+void progress_tracker::end()
+{
+    if(!running) return;
+
+    running = false;
+    cv.notify_all();
+    poll_thread->join();
+    tracking_resources.clear();
+    // Show cursor again
+    std::cout << "\x1b[?25h";
+}
+
+void progress_tracker::prepare_frame(size_t device_index, uint32_t frame_index, uint64_t frame)
+{
+    if(running)
+    {
+        tracking_resources[device_index].frame_buffer_ptr[frame_index] = frame;
+    }
+}
+
+void progress_tracker::record_tracking(size_t device_index, vk::CommandBuffer cmd, uint32_t frame_index, uint32_t step)
+{
+    if(running)
+    {
+        if(step == 0)
+        {
+            cmd.copyBuffer(
+                *tracking_resources[device_index].frame_buffer,
+                *tracking_resources[device_index].tracking_data,
+                vk::BufferCopy(frame_index * sizeof(uint32_t), 0, sizeof(uint32_t))
+            );
+        }
+        cmd.updateBuffer(
+            *tracking_resources[device_index].tracking_data,
+            sizeof(uint32_t),
+            sizeof(uint32_t),
+            &step
+        );
+    }
+}
+
+bool progress_tracker::tracking_stamp::operator<(const tracking_stamp& other) const
+{
+    if(frame < other.frame) return true;
+    else if(frame > other.frame) return false;
+    else return step < other.step;
+}
+
+bool progress_tracker::tracking_stamp::operator==(const tracking_stamp& other) const
+{
+    return frame == other.frame && step == other.step;
+}
+
+void progress_tracker::update_progress_bar(
+    std::chrono::steady_clock::time_point start,
+    const tracking_stamp& latest
+){
+    if(latest.frame >= opt.expected_frame_count)
+        opt.expected_frame_count = latest.frame;
+
+    if(latest.step >= opt.expected_steps_per_frame)
+        opt.expected_steps_per_frame = latest.step;
+
+    size_t total_steps = opt.expected_frame_count * opt.expected_steps_per_frame;
+    size_t cur_steps = (latest.frame-1) * opt.expected_steps_per_frame + latest.step;
+    float progress = float(cur_steps) / float(total_steps);
+
+    auto delta = std::chrono::duration_cast<std::chrono::duration<float>>(
+        std::chrono::steady_clock::now() - start).count();
+
+    float total_time = delta / progress;
+    int time_left = ceil(total_time - delta);
+
+    int bar_width = 80-2;
+    int fill_width = bar_width * progress;
+    std::cout << "\r\x1b[?25l\x1b[2K[";
+    for(int i = 0; i < bar_width; ++i)
+    {
+        char c = ' ';
+        if(i < fill_width || cur_steps == total_steps) c = '=';
+        else if(i == fill_width) c = '>';
+
+        std::cout << c;
+    }
+    std::cout << "] ";
+
+    std::cout << std::setprecision(1) << 100.0f * progress << "%, ";
+    int hours = time_left / 3600;
+    if(hours > 0) std::cout << hours << "h ";
+    time_left %= 3600;
+
+    int minutes = time_left / 60;
+    if(minutes > 0) std::cout << minutes << "m ";
+    time_left %= 60;
+
+    std::cout << time_left << "s left";
+
+    std::cout << std::flush;
+}
+
+void progress_tracker::poll_worker(progress_tracker* self)
+{
+    std::mutex wait_mutex;
+    std::unique_lock<std::mutex> lk(wait_mutex);
+    tracking_stamp latest = {0, 0};
+
+    std::vector<device_data>& devices = self->ctx->get_devices();
+
+    std::chrono::steady_clock::time_point start_time;
+    bool first = true;
+
+    while(self->running)
+    {
+        self->cv.wait_for(lk, std::chrono::milliseconds(self->opt.poll_ms));
+
+        tracking_stamp oldest;
+
+        bool failed = false;
+        for(size_t i = 0; i < devices.size(); ++i)
+        {
+            tracking_stamp stamp = *self->tracking_resources[i].tracking_data_ptr;
+            if(stamp < self->tracking_resources[i].last_value)
+            {
+                failed = true;
+                break;
+            }
+            self->tracking_resources[i].last_value = stamp;
+            if(i == 0 || stamp < oldest)
+                oldest = stamp;
+        }
+        if(failed) continue;
+
+        if(!(latest == oldest))
+        {
+            latest = oldest;
+            if(first)
+            {
+                start_time = std::chrono::steady_clock::now();
+                first = false;
+            }
+            self->update_progress_bar(start_time, latest);
+        }
+    }
+}
+
+}

--- a/src/progress_tracker.hh
+++ b/src/progress_tracker.hh
@@ -1,0 +1,72 @@
+#ifndef TAURAY_PROGRESS_TRACKER_HH
+#define TAURAY_PROGRESS_TRACKER_HH
+
+#include "vkm.hh"
+#include <chrono>
+#include <optional>
+#include <condition_variable>
+#include <thread>
+
+namespace tr
+{
+
+class context;
+
+class progress_tracker
+{
+public:
+    progress_tracker(context* ctx);
+    ~progress_tracker();
+
+    struct options
+    {
+        size_t expected_frame_count;
+        size_t expected_steps_per_frame;
+        size_t poll_ms = 10;
+    };
+
+    void begin(options opt);
+    void end();
+
+    void prepare_frame(size_t device_index, uint32_t frame_index, uint64_t frame);
+    void record_tracking(size_t device_index, vk::CommandBuffer cmd, uint32_t frame_index, uint32_t step);
+
+private:
+    struct tracking_stamp
+    {
+        uint32_t frame = 0;
+        uint32_t step = 0;
+
+        bool operator<(const tracking_stamp& other) const;
+        bool operator==(const tracking_stamp& other) const;
+    };
+
+    void update_progress_bar(
+        std::chrono::steady_clock::time_point start,
+        const tracking_stamp& latest
+    );
+
+    context* ctx;
+    options opt;
+    std::optional<std::thread> poll_thread;
+    std::condition_variable cv;
+    bool running;
+
+    static void poll_worker(progress_tracker* self);
+
+    struct tracking_data
+    {
+        vkm<vk::Buffer> frame_buffer;
+        uint32_t* frame_buffer_ptr;
+        vkm<vk::Buffer> tracking_data;
+        tracking_stamp* tracking_data_ptr;
+        tracking_stamp last_value;
+    };
+    std::vector<tracking_data> tracking_resources;
+};
+
+}
+
+#endif
+
+

--- a/src/rt_camera_stage.cc
+++ b/src/rt_camera_stage.cc
@@ -91,6 +91,9 @@ void rt_camera_stage::update(uint32_t frame_index)
         }
     );
 
+    uint64_t frame = dev->ctx->get_frame_counter();
+    dev->ctx->get_progress_tracker().prepare_frame(dev->index, frame_index, frame);
+
     for(size_t i = 0; i < opt.active_viewport_count; ++i)
     {
         camera* cam = get_scene()->get_camera(i);
@@ -162,6 +165,7 @@ void rt_camera_stage::record_command_buffer(
 
     if(pass_index == 0)
     {
+        dev->ctx->get_progress_tracker().record_tracking(dev->index, cb, frame_index, 0);
         distribution_data.upload(frame_index, cb);
         cb.pipelineBarrier(
             vk::PipelineStageFlagBits::eTopOfPipe,
@@ -192,6 +196,13 @@ void rt_camera_stage::record_command_buffer(
             {}, {}, {}, out_barriers
         );
     }
+
+    dev->ctx->get_progress_tracker().record_tracking(
+        dev->index,
+        cb,
+        frame_index,
+        opt.samples_per_pixel * (pass_index+1)/ get_pass_count()
+    );
 }
 
 }

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -1027,6 +1027,20 @@ void replay_viewer(context& ctx, scene_data& sd, options& opt)
     bool is_animated = s.is_playing();
     if(!opt.frames && !is_animated) frame_count = 1;
 
+    if(opt.progress && frame_count != size_t(-1))
+    {
+        progress_tracker::options popt;
+        popt.expected_frame_count = frame_count;
+        popt.expected_steps_per_frame = 1;
+        if(auto rtype = std::get_if<options::basic_pipeline_type>(&opt.renderer))
+        {
+            if(*rtype == options::PATH_TRACER || *rtype == options::DIRECT)
+                popt.expected_steps_per_frame = opt.samples_per_pixel;
+        }
+
+        ctx.get_progress_tracker().begin(popt);
+    }
+
     for(size_t i = 0; i < frame_count; ++i)
     {
         if(!opt.frames && is_animated && !s.is_playing())


### PR DESCRIPTION
It's often useful to see how long it'll take to render, so this PR adds a new `-p` flag to enable a progress bar in headless/offline rendering.