### PR TITLE
Scene refactoring

### DIFF
--- a/src/aabb_scene.cc
+++ b/src/aabb_scene.cc
@@ -1,70 +1,6 @@
 #include "aabb_scene.hh"
 #include "misc.hh"
 
-namespace
-{
-using namespace tr;
-
-void record_blas_update(
-    vk::CommandBuffer& cb,
-    vk::AccelerationStructureKHR blas,
-    size_t total_aabb_count,
-    gpu_buffer& aabb_buffer,
-    vkm<vk::Buffer>& scratch_buffer,
-    bool update,
-    timer& update_timer,
-    uint32_t frame_index
-){
-    if(total_aabb_count == 0)
-        return;
-
-    update_timer.begin(cb, frame_index);
-    aabb_buffer.upload(frame_index, cb);
-
-    vk::MemoryBarrier barrier(
-        vk::AccessFlagBits::eTransferWrite,
-        vk::AccessFlagBits::eAccelerationStructureWriteKHR
-    );
-
-    cb.pipelineBarrier(
-        vk::PipelineStageFlagBits::eTransfer,
-        vk::PipelineStageFlagBits::eAccelerationStructureBuildKHR,
-        {},
-        barrier, {}, {}
-    );
-
-    vk::AccelerationStructureGeometryKHR geom(
-        vk::GeometryTypeKHR::eAabbs,
-        vk::AccelerationStructureGeometryAabbsDataKHR(
-            aabb_buffer.get_address(),
-            sizeof(vk::AabbPositionsKHR)
-        ),
-        vk::GeometryFlagBitsKHR::eOpaque
-    );
-
-    vk::AccelerationStructureBuildGeometryInfoKHR blas_build_info(
-        vk::AccelerationStructureTypeKHR::eBottomLevel,
-        vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace|
-        vk::BuildAccelerationStructureFlagBitsKHR::eAllowUpdate,
-        update ? vk::BuildAccelerationStructureModeKHR::eUpdate : vk::BuildAccelerationStructureModeKHR::eBuild,
-        update ? blas : vk::AccelerationStructureKHR{},
-        blas,
-        1,
-        &geom,
-        nullptr,
-        scratch_buffer.get_address()
-    );
-
-    vk::AccelerationStructureBuildRangeInfoKHR offset(
-        total_aabb_count, 0, 0, 0
-    );
-
-    cb.buildAccelerationStructuresKHR({blas_build_info}, {&offset});
-    update_timer.end(cb, frame_index);
-}
-
-}
-
 namespace tr
 {
 
@@ -89,11 +25,11 @@ void aabb_scene::update_acceleration_structures(
     bool& need_scene_reset,
     bool& command_buffers_outdated
 ){
-    auto& as = acceleration_structures[device_index];
+    auto& as = as_update[device_index];
     auto& f = as.per_frame[frame_index];
 
     // Update area point light buffer
-    as.aabb_buffer.map<vk::AabbPositionsKHR>(
+    aabb_buffer[device_index].map<vk::AabbPositionsKHR>(
         frame_index,
         [&](vk::AabbPositionsKHR* aabb){
             f.aabb_count = get_aabbs(aabb);
@@ -113,19 +49,20 @@ void aabb_scene::record_acceleration_structure_build(
     uint32_t frame_index,
     bool update_only
 ){
-    auto& as = acceleration_structures[device_index];
+    auto& as = as_update[device_index];
     auto& f = as.per_frame[frame_index];
 
-    record_blas_update(
+    as.blas_update_timer.begin(cb, frame_index);
+    aabb_buffer[device_index].upload(frame_index, cb);
+
+    blas->rebuild(
+        device_index,
+        frame_index,
         cb,
-        as.blas,
-        f.aabb_count,
-        as.aabb_buffer,
-        as.scratch_buffer,
-        update_only,
-        as.blas_update_timer,
-        frame_index
+        {bottom_level_acceleration_structure::entry{nullptr, f.aabb_count, aabb_buffer.data(), mat4(1.0f), true}},
+        update_only
     );
+    as.blas_update_timer.end(cb, frame_index);
 }
 
 void aabb_scene::add_acceleration_structure_instances(
@@ -136,7 +73,7 @@ void aabb_scene::add_acceleration_structure_instances(
     size_t capacity
 ) const
 {
-    auto& as = acceleration_structures[device_index];
+    auto& as = as_update[device_index];
     auto& f = as.per_frame[frame_index];
 
     if(f.aabb_count != 0 && instance_index < capacity)
@@ -145,7 +82,7 @@ void aabb_scene::add_acceleration_structure_instances(
         inst = vk::AccelerationStructureInstanceKHR(
             {}, instance_index, 1<<1, sbt_offset,
             vk::GeometryInstanceFlagBitsKHR::eTriangleCullDisable,
-            as.blas_buffer.get_address()
+            blas->get_blas_address(device_index)
         );
         mat4 id_mat = mat4(1.0f);
         memcpy((void*)&inst.transform, (void*)&id_mat, sizeof(inst.transform));
@@ -157,12 +94,13 @@ void aabb_scene::init_acceleration_structures(const char* timer_name)
     if(!ctx->is_ray_tracing_supported()) return;
 
     std::vector<device_data>& devices = ctx->get_devices();
-    acceleration_structures.resize(devices.size());
+    as_update.resize(devices.size());
+    aabb_buffer.clear();
 
     for(size_t i = 0; i < devices.size(); ++i)
     {
-        auto& as = acceleration_structures[i];
-        as.aabb_buffer = gpu_buffer(
+        auto& as = as_update[i];
+        aabb_buffer.emplace_back(
             devices[i], max_capacity * sizeof(vk::AabbPositionsKHR),
             vk::BufferUsageFlagBits::eStorageBuffer |
             vk::BufferUsageFlagBits::eTransferDst |
@@ -170,77 +108,20 @@ void aabb_scene::init_acceleration_structures(const char* timer_name)
             vk::BufferUsageFlagBits::eAccelerationStructureBuildInputReadOnlyKHR
         );
 
-        vk::AccelerationStructureGeometryKHR geom(
-            VULKAN_HPP_NAMESPACE::GeometryTypeKHR::eAabbs,
-            vk::AccelerationStructureGeometryAabbsDataKHR(
-                as.aabb_buffer.get_address(), sizeof(vk::AabbPositionsKHR)
-            ),
-            vk::GeometryFlagBitsKHR::eOpaque
-        );
-
-        vk::AccelerationStructureBuildGeometryInfoKHR blas_info(
-            vk::AccelerationStructureTypeKHR::eBottomLevel,
-            vk::BuildAccelerationStructureFlagBitsKHR::ePreferFastTrace|
-            vk::BuildAccelerationStructureFlagBitsKHR::eAllowUpdate,
-            vk::BuildAccelerationStructureModeKHR::eBuild,
-            VK_NULL_HANDLE,
-            VK_NULL_HANDLE,
-            1,
-            &geom
-        );
-
-        vk::AccelerationStructureBuildSizesInfoKHR size_info =
-            devices[i].dev.getAccelerationStructureBuildSizesKHR(
-                vk::AccelerationStructureBuildTypeKHR::eDevice, blas_info,
-                {(uint32_t)max_capacity}
-            );
-
-        vk::BufferCreateInfo blas_buffer_info(
-            {}, size_info.accelerationStructureSize,
-            vk::BufferUsageFlagBits::eAccelerationStructureStorageKHR|
-            vk::BufferUsageFlagBits::eShaderDeviceAddress,
-            vk::SharingMode::eExclusive
-        );
-        as.blas_buffer = create_buffer(
-            devices[i],
-            blas_buffer_info,
-            VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT
-        );
-
-        vk::AccelerationStructureCreateInfoKHR create_info(
-            {},
-            as.blas_buffer,
-            {},
-            size_info.accelerationStructureSize,
-            vk::AccelerationStructureTypeKHR::eBottomLevel,
-            {}
-        );
-        as.blas = vkm(
-            devices[i],
-            devices[i].dev.createAccelerationStructureKHR(create_info)
-        );
-        blas_info.dstAccelerationStructure = as.blas;
-
-        vk::BufferCreateInfo scratch_info(
-            {}, size_info.buildScratchSize,
-            vk::BufferUsageFlagBits::eStorageBuffer|
-            vk::BufferUsageFlagBits::eShaderDeviceAddress,
-            vk::SharingMode::eExclusive
-        );
-        as.scratch_buffer = create_buffer_aligned(
-            devices[i],
-            scratch_info,
-            VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT,
-            devices[i].as_props.minAccelerationStructureScratchOffsetAlignment
-        );
-
         as.blas_update_timer = timer(devices[i], timer_name);
     }
+    blas.emplace(
+        *ctx,
+        std::vector<bottom_level_acceleration_structure::entry>{
+            {nullptr, max_capacity, aabb_buffer.data(), mat4(1.0f), true}
+        },
+        false, true, false
+    );
 }
 
 void aabb_scene::invalidate_acceleration_structures()
 {
-    for(auto& as: acceleration_structures)
+    for(auto& as: as_update)
     {
         as.scene_reset_needed = true;
         for(auto& f: as.per_frame)

--- a/src/aabb_scene.hh
+++ b/src/aabb_scene.hh
@@ -2,6 +2,7 @@
 #define TAURAY_AABB_SCENE_HH
 #include "context.hh"
 #include "timer.hh"
+#include "acceleration_structure.hh"
 #include "gpu_buffer.hh"
 
 namespace tr
@@ -60,14 +61,11 @@ private:
     size_t max_capacity;
     size_t sbt_offset;
 
-    struct acceleration_structure_data
+    std::optional<bottom_level_acceleration_structure> blas;
+    std::vector<gpu_buffer> aabb_buffer;
+    struct as_update_data
     {
         bool scene_reset_needed = true;
-
-        vkm<vk::AccelerationStructureKHR> blas;
-        vkm<vk::Buffer> blas_buffer;
-        vkm<vk::Buffer> scratch_buffer;
-        gpu_buffer aabb_buffer;
 
         struct per_frame_data
         {
@@ -77,7 +75,7 @@ private:
         per_frame_data per_frame[MAX_FRAMES_IN_FLIGHT];
         timer blas_update_timer;
     };
-    std::vector<acceleration_structure_data> acceleration_structures;
+    std::vector<as_update_data> as_update;
 };
 
 }

--- a/src/acceleration_structure.hh
+++ b/src/acceleration_structure.hh
@@ -14,8 +14,13 @@ class bottom_level_acceleration_structure
 public:
     struct entry
     {
+        // If nullptr, this entry is AABBs instead of a triangle mesh.
         const mesh* m = nullptr;
-        mat4 transform = mat4(1);
+        size_t aabb_count = 0;
+        // Pointer to array of AABB buffers, indexed by device index
+        gpu_buffer* aabb_buffer = nullptr;
+
+        mat4 transform = mat4(1.0f);
         bool opaque = true;
     };
 

--- a/src/mesh_scene.cc
+++ b/src/mesh_scene.cc
@@ -296,6 +296,7 @@ void mesh_scene::refresh_dynamic_acceleration_structures(
             const instance& inst = instance_cache[offset];
             entries.push_back({
                 inst.m,
+                0, nullptr,
                 group.static_transformable ? inst.transform : mat4(1),
                 !inst.mat->potentially_transparent()
             });
@@ -347,6 +348,7 @@ void mesh_scene::update_acceleration_structures(
                 const instance& inst = instance_cache[offset];
                 entries.push_back({
                     inst.m,
+                    0, nullptr,
                     group.static_transformable ? inst.transform : mat4(1),
                     !inst.mat->potentially_transparent()
                 });
@@ -437,6 +439,7 @@ void mesh_scene::ensure_blas()
             if(inst.mat->double_sided) double_sided = true;
             entries.push_back({
                 inst.m,
+                0, nullptr,
                 group.static_transformable ? inst.transform : mat4(1),
                 !inst.mat->potentially_transparent()
             });


### PR DESCRIPTION
The eventual intent of this PR is to remove `aabb_scene` and `light_scene` and merge their contents to `scene`. Further, `scene_update_stage` should take a more controlling role, containing all of the code related to scene updates and some GPU-side scene data structures as well. Once the `scene` class has been reduced to a simple container of lights, objects and cameras, it will be much easier to move to an ECS.

This is a step towards #27.