### PR TITLE
Add option to manually calibrate LKG displays

### DIFF
--- a/src/looking_glass.hh
+++ b/src/looking_glass.hh
@@ -41,6 +41,25 @@ public:
         float mid_plane_dist = 2.0f;
         float depthiness = 2.0f;
         float relative_view_distance = 2.0f;
+
+        struct calibration_data
+        {
+            int display_index;
+            float pitch;
+            float slope;
+            float center;
+            float fringe;
+            float viewCone;
+            int invView;
+            float verticalAngle;
+            float DPI;
+            int screenW;
+            int screenH;
+            int flipImageX;
+            int flipImageY;
+            int flipSubp;
+        };
+        std::optional<calibration_data> calibration_override;
     };
 
     looking_glass(const options& opt);
@@ -87,9 +106,6 @@ private:
         float slope = 0;
         float vertical_angle = 0;
         float view_cone = 0;
-        float quilt_aspect = 0;
-        uvec2 quilt_size = uvec2(0);
-        uvec2 tile_count = uvec2(0);
         std::string hardware_version;
         std::string hardware_id;
         size_t index;

--- a/src/options.hh
+++ b/src/options.hh
@@ -381,10 +381,30 @@
         "convergence from the camera, d is the \"depthiness\", and " \
         "r is the view distance (relative to display size) used for "\
         "calculating the vertical FOV.", \
-        TR_STRUCT_OPT_INT(v, 48, 1, INT_MAX) \
-        TR_STRUCT_OPT_FLOAT(m, 2.0f, 0.001f, FLT_MAX) \
-        TR_STRUCT_OPT_FLOAT(d, 2.0f, 0.001f, FLT_MAX) \
-        TR_STRUCT_OPT_FLOAT(r, 2.0f, 0.001f, FLT_MAX) \
+        TR_STRUCT_OPT_INT(viewports, 48, 1, INT_MAX) \
+        TR_STRUCT_OPT_FLOAT(midplane, 2.0f, 0.001f, FLT_MAX) \
+        TR_STRUCT_OPT_FLOAT(depth, 2.0f, 0.001f, FLT_MAX) \
+        TR_STRUCT_OPT_FLOAT(relative_dist, 2.0f, 0.001f, FLT_MAX) \
+    )\
+    TR_STRUCT_OPT(lkg_calibration, \
+        "Overrides calibration parameters for a Looking Glass display. " \
+        "Can be used to run one such display without the USB connection. " \
+        "These values can be found from the LKG_calibration folder if you " \
+        "mount the display USB as a drive.", \
+        TR_STRUCT_OPT_INT(display_index, -1, 0, INT_MAX) \
+        TR_STRUCT_OPT_FLOAT(pitch, 0, -FLT_MAX, FLT_MAX) \
+        TR_STRUCT_OPT_FLOAT(slope, 0, -FLT_MAX, FLT_MAX) \
+        TR_STRUCT_OPT_FLOAT(center, 0, -FLT_MAX, FLT_MAX) \
+        TR_STRUCT_OPT_FLOAT(fringe, 0, -FLT_MAX, FLT_MAX) \
+        TR_STRUCT_OPT_FLOAT(viewCone, 0, 0.0f, FLT_MAX) \
+        TR_STRUCT_OPT_INT(invView, 0, 0, 1) \
+        TR_STRUCT_OPT_FLOAT(verticalAngle, 0, -FLT_MAX, FLT_MAX) \
+        TR_STRUCT_OPT_FLOAT(DPI, 0, 0, FLT_MAX) \
+        TR_STRUCT_OPT_INT(screenW, 0, 1, INT_MAX) \
+        TR_STRUCT_OPT_INT(screenH, 0, 1, INT_MAX) \
+        TR_STRUCT_OPT_INT(flipImageX, 0, 0, 1) \
+        TR_STRUCT_OPT_INT(flipImageY, 0, 0, 1) \
+        TR_STRUCT_OPT_INT(flipSubp, 0, 0, 1) \
     )\
     TR_STRUCT_OPT(taa, \
         "Sets parameters for temporal antialiasing.", \

--- a/src/tauray.cc
+++ b/src/tauray.cc
@@ -325,10 +325,16 @@ context* create_context(const options& opt)
         (context::options&)lkg_opt = ctx_opt;
         lkg_opt.vsync = opt.vsync;
         lkg_opt.viewport_size = uvec2(opt.width, opt.height);
-        lkg_opt.viewport_count = opt.lkg_params.v;
-        lkg_opt.mid_plane_dist = opt.lkg_params.m;
-        lkg_opt.depthiness = opt.lkg_params.d;
-        lkg_opt.relative_view_distance = opt.lkg_params.r;
+        lkg_opt.viewport_count = opt.lkg_params.viewports;
+        lkg_opt.mid_plane_dist = opt.lkg_params.midplane;
+        lkg_opt.depthiness = opt.lkg_params.depth;
+        lkg_opt.relative_view_distance = opt.lkg_params.relative_dist;
+        if(opt.lkg_calibration.display_index >= 0)
+        {
+            looking_glass::options::calibration_data calib;
+            memcpy(&calib, &opt.lkg_calibration, sizeof(calib));
+            lkg_opt.calibration_override.emplace(calib);
+        }
         return new looking_glass(lkg_opt);
     }
     else if(opt.display == options::display_type::FRAME_SERVER)


### PR DESCRIPTION
Their new "Bridge" software seems to be unreliable, at least on Windows :( So since we often want to use this display for various demonstrations, this option lets us to just give it the correct calibration parameters in a config file. And with this, it's not even necessary to plug the USB to the computer running the display.