### PR TITLE
Fix synchronization hazards

### DIFF
--- a/src/misc.cc
+++ b/src/misc.cc
@@ -351,11 +351,6 @@ void deduce_layout_access_stage(
 ){
     switch(layout)
     {
-    case vk::ImageLayout::eUndefined:
-    case vk::ImageLayout::ePresentSrcKHR:
-        access = {};
-        stage = vk::PipelineStageFlagBits::eTopOfPipe;
-        break;
     case vk::ImageLayout::eTransferDstOptimal:
         access = vk::AccessFlagBits::eTransferWrite;
         stage = vk::PipelineStageFlagBits::eTransfer;
@@ -381,9 +376,11 @@ void deduce_layout_access_stage(
             vk::AccessFlagBits::eDepthStencilAttachmentWrite;
         stage = vk::PipelineStageFlagBits::eEarlyFragmentTests;
         break;
+    case vk::ImageLayout::eUndefined:
     case vk::ImageLayout::eGeneral:
+    case vk::ImageLayout::ePresentSrcKHR:
         access = vk::AccessFlagBits::eMemoryRead | vk::AccessFlagBits::eMemoryWrite;
-        stage = vk::PipelineStageFlagBits::eTopOfPipe;
+        stage = vk::PipelineStageFlagBits::eAllCommands;
         break;
     default:
         throw std::runtime_error("Unknown layout " + std::to_string((uint64_t)layout));
@@ -510,6 +507,20 @@ void full_barrier(vk::CommandBuffer cb)
     cb.pipelineBarrier(
         vk::PipelineStageFlagBits::eAllCommands,
         vk::PipelineStageFlagBits::eAllCommands,
+        {}, barrier, {}, {}
+    );
+}
+
+void bulk_upload_barrier(vk::CommandBuffer cb, vk::PipelineStageFlags usage_flags)
+{
+    vk::MemoryBarrier barrier(
+        vk::AccessFlagBits::eMemoryWrite,
+        vk::AccessFlagBits::eMemoryRead
+    );
+
+    cb.pipelineBarrier(
+        vk::PipelineStageFlagBits::eTransfer,
+        usage_flags,
         {}, barrier, {}, {}
     );
 }

--- a/src/misc.hh
+++ b/src/misc.hh
@@ -105,6 +105,10 @@ vkm<vk::Image> sync_create_gpu_image(
 
 // The hammer for all problems (if you don't care about performance at all)
 void full_barrier(vk::CommandBuffer cb);
+void bulk_upload_barrier(
+    vk::CommandBuffer cb,
+    vk::PipelineStageFlags usage_flags = vk::PipelineStageFlagBits::eAllCommands
+);
 
 vk::SampleCountFlagBits get_max_available_sample_count(context& ctx);
 

--- a/src/scene_update_stage.cc
+++ b/src/scene_update_stage.cc
@@ -622,6 +622,8 @@ void scene_update_stage::record_command_buffers()
         sb.camera_data.upload(i, cb);
         sb.scene_metadata.upload(i, cb);
 
+        bulk_upload_barrier(cb, vk::PipelineStageFlagBits::eComputeShader);
+
         if(dev->ctx->is_ray_tracing_supported())
         {
             record_as_build(i, cb);

--- a/src/tonemap_stage.cc
+++ b/src/tonemap_stage.cc
@@ -96,6 +96,7 @@ tonemap_stage::tonemap_stage(
         output.transition_layout_temporary(cb, j, vk::ImageLayout::eGeneral, true);
 
         index_data.upload(i, cb);
+        bulk_upload_barrier(cb, vk::PipelineStageFlagBits::eComputeShader);
         tonemap_timer.begin(cb, i);
 
         comp.bind(cb, cb_index);


### PR DESCRIPTION
Fixes #38. Some buffer uploads were missing barriers, and some image layout transitions were using incorrect flags. 