### PR TITLE
Fix headless mode when writing image to file

### DIFF
--- a/src/headless.cc
+++ b/src/headless.cc
@@ -4,6 +4,7 @@
 #include "tinyexr.h"
 #include "stb_image_write.h"
 #include <iostream>
+#include <filesystem>
 #include <fstream>
 #include <cstring>
 
@@ -79,6 +80,12 @@ headless::headless(const options& opt)
         throw std::runtime_error(
             "More than one display is only allowed in fully headless mode"
         );
+
+    // Create the directory if it doesn't exist
+    std::filesystem::path output_dir(opt.output_prefix);
+    output_dir.remove_filename();
+    if(!std::filesystem::exists(output_dir))
+        std::filesystem::create_directories(output_dir);
 
     if(opt.viewer) init_sdl();
     init_vulkan(vkGetInstanceProcAddr);


### PR DESCRIPTION
Fixed runtime error with headless mode when attempting to write an image to a non-existent directory. 