### PR TITLE
WIP: Add debug labels to Vulkan objects

### DIFF
--- a/shader/bmfr_accumulate_output.comp
+++ b/shader/bmfr_accumulate_output.comp
@@ -90,7 +90,7 @@ void main()
         if (sum_w > 0.001 && !any(isnan(diffuse_prev)))
         {
             float hist_len = diffuse_prev.a;
-            float alpha_color = max(0.01, 1.0 / hist_len);
+            float alpha_color = clamp(1.0 / hist_len, 0.01, 1.0);
             hist_len = min(hist_len + 1.0, 255.0);
             diffuse_curr.a = hist_len;
             diffuse_curr.rgb = mix(diffuse_prev.rgb, diffuse_curr.rgb, alpha_color);

--- a/shader/bmfr_preprocess.comp
+++ b/shader/bmfr_preprocess.comp
@@ -172,9 +172,9 @@ void main()
     if (sum_w > 0.001 && !any(isnan(diffuse_prev)))
     {
         float hist_len = diffuse_prev.a;
-        float alpha_color = max(0.01, 1.0/hist_len);
-
         hist_len = min(hist_len + 1.0, 255.0);
+        float alpha_color = clamp(1.0/hist_len, 0.01, 1.0);
+
         diffuse.a = hist_len;
         diffuse.rgb = mix(diffuse_prev.rgb, diffuse.rgb, alpha_color);
         specular.rgb = mix(specular_prev.rgb, specular.rgb, alpha_color);
@@ -184,7 +184,7 @@ void main()
         imageStore(tmp_noisy[0], p, diffuse);
         imageStore(tmp_noisy[1], p, specular);
     }
-        
+
 
     const float features[BUFFER_COUNT] = {
         1.f,

--- a/src/bmfr_stage.cc
+++ b/src/bmfr_stage.cc
@@ -148,6 +148,9 @@ void bmfr_stage::init_resources()
     bmfr_weighted_sum_desc.reset(dev->id, MAX_FRAMES_IN_FLIGHT);
     bmfr_accumulate_output_desc.reset(dev->id, MAX_FRAMES_IN_FLIGHT);
 
+    // Used to get current frame index for block offsetting and seeding RNG
+    uniform_buffer = gpu_buffer(*dev, 4, vk::BufferUsageFlagBits::eUniformBuffer);
+
     for(size_t i = 0; i < MAX_FRAMES_IN_FLIGHT; ++i)
     {
         uvec2 wg = (current_features.get_size()+(BLOCK_SIZE - 1))/BLOCK_SIZE + 1u; // + 1 for margins
@@ -193,9 +196,6 @@ void bmfr_stage::init_resources()
             accepts[i] = create_buffer(*dev, bufferInfo, VMA_ALLOCATION_CREATE_DEDICATED_MEMORY_BIT, nullptr);
         }
 
-        // Used to get current frame index for block offsetting and seeding RNG
-        ubos = gpu_buffer(*dev, 4, vk::BufferUsageFlagBits::eUniformBuffer);
-
         bmfr_preprocess_desc.set_image(dev->id, i, "in_color", {{{}, current_features.color.view, vk::ImageLayout::eGeneral}});
         bmfr_preprocess_desc.set_image(dev->id, i, "in_normal", {{{}, current_features.normal.view, vk::ImageLayout::eGeneral}});
         bmfr_preprocess_desc.set_image(dev->id, i, "in_pos", {{{}, current_features.pos.view, vk::ImageLayout::eGeneral}});
@@ -208,13 +208,13 @@ void bmfr_stage::init_resources()
         bmfr_preprocess_desc.set_image(dev->id, i, "bmfr_diffuse_hist", {{{}, diffuse_hist.view, vk::ImageLayout::eGeneral}});
         bmfr_preprocess_desc.set_image(dev->id, i, "bmfr_specular_hist", {{{}, specular_hist.view, vk::ImageLayout::eGeneral}});
         bmfr_preprocess_desc.set_buffer(dev->id, i, "tmp_buffer", {{tmp_data[i], 0, VK_WHOLE_SIZE}});
-        bmfr_preprocess_desc.set_buffer(dev->id, i, "uniform_buffer", {{ubos[dev->id], 0, VK_WHOLE_SIZE}});
+        bmfr_preprocess_desc.set_buffer(dev->id, i, "uniform_buffer", {{uniform_buffer[dev->id], 0, VK_WHOLE_SIZE}});
         bmfr_preprocess_desc.set_buffer(dev->id, i, "accept_buffer", {{accepts[i], 0, VK_WHOLE_SIZE}});
 
         bmfr_fit_desc.set_buffer(dev->id, i, "tmp_buffer", {{tmp_data[i], 0, VK_WHOLE_SIZE}});
         bmfr_fit_desc.set_buffer(dev->id, i, "mins_maxs_buffer", {{min_max_buffer[i], 0, VK_WHOLE_SIZE}});
         bmfr_fit_desc.set_buffer(dev->id, i, "weights_buffer", {{weights[i], 0, VK_WHOLE_SIZE}});
-        bmfr_fit_desc.set_buffer(dev->id, i, "uniform_buffer", {{ubos[dev->id], 0, VK_WHOLE_SIZE}});
+        bmfr_fit_desc.set_buffer(dev->id, i, "uniform_buffer", {{uniform_buffer[dev->id], 0, VK_WHOLE_SIZE}});
         bmfr_fit_desc.set_image(dev->id, i, "in_color", {{{}, current_features.color.view, vk::ImageLayout::eGeneral}});
 
         bmfr_weighted_sum_desc.set_buffer(dev->id, i, "weights_buffer", {{weights[i], 0, VK_WHOLE_SIZE}});
@@ -223,7 +223,7 @@ void bmfr_stage::init_resources()
         bmfr_weighted_sum_desc.set_image(dev->id, i, "in_pos", {{{}, current_features.pos.view, vk::ImageLayout::eGeneral}});
         bmfr_weighted_sum_desc.set_buffer(dev->id, i, "mins_maxs_buffer", {{min_max_buffer[i], 0, VK_WHOLE_SIZE}});
         bmfr_weighted_sum_desc.set_image(dev->id, i, "in_diffuse", {{{}, current_features.diffuse.view, vk::ImageLayout::eGeneral}});
-        bmfr_weighted_sum_desc.set_buffer(dev->id, i, "uniform_buffer", {{ubos[dev->id], 0, VK_WHOLE_SIZE}});
+        bmfr_weighted_sum_desc.set_buffer(dev->id, i, "uniform_buffer", {{uniform_buffer[dev->id], 0, VK_WHOLE_SIZE}});
         bmfr_weighted_sum_desc.set_image(dev->id, i, "weighted_out", {{{}, weighted_sum[0].view, vk::ImageLayout::eGeneral}, {{}, weighted_sum[1].view, vk::ImageLayout::eGeneral}});
         bmfr_weighted_sum_desc.set_image(dev->id, i, "tmp_noisy", {{{}, tmp_noisy[0].view, vk::ImageLayout::eGeneral}, {{}, tmp_noisy[1].view, vk::ImageLayout::eGeneral}});
 
@@ -247,7 +247,7 @@ void bmfr_stage::record_command_buffers()
 
         stage_timer.begin(cb, dev->id, i);
 
-        ubos.upload(dev->id, i, cb);
+        uniform_buffer.upload(dev->id, i, cb);
         uvec2 workset_size = ((current_features.get_size()+(31u))/32u) + 1u; // One workset = one 32*32 block
         uvec2 wg = (current_features.get_size()+15u)/16u;
         push_constant_buffer control;
@@ -330,7 +330,7 @@ void bmfr_stage::record_command_buffers()
 void bmfr_stage::update(uint32_t frame_index)
 {
     uint32_t frame_counter = dev->ctx->get_frame_counter();
-    ubos.update(frame_index, &frame_counter, 0, sizeof(uint32_t));
+    uniform_buffer.update(frame_index, &frame_counter, 0, sizeof(uint32_t));
 }
 
 void bmfr_stage::copy_image(vk::CommandBuffer& cb, render_target& src, render_target& dst)

--- a/src/bmfr_stage.hh
+++ b/src/bmfr_stage.hh
@@ -62,7 +62,7 @@ private:
     vkm<vk::Buffer> tmp_data[MAX_FRAMES_IN_FLIGHT];
     vkm<vk::Buffer> weights[MAX_FRAMES_IN_FLIGHT];
     vkm<vk::Buffer> accepts[MAX_FRAMES_IN_FLIGHT];
-    gpu_buffer ubos;
+    gpu_buffer uniform_buffer;
     std::unique_ptr<texture> rt_textures[10];
     options opt;
     timer stage_timer, bmfr_preprocess_timer, bmfr_fit_timer, bmfr_weighted_sum_timer, bmfr_accumulate_output_timer, image_copy_timer;

--- a/src/gbuffer.cc
+++ b/src/gbuffer.cc
@@ -160,6 +160,7 @@ void gbuffer_texture::reset(
             initial_layout,\
             msaa\
         ));\
+        for (const auto& dev : mask) set_debug_object_name(dev, name->get_image(dev.id), #name);\
     }\
     bool gbuffer_texture::has_##name() const\
     {\

--- a/src/misc.hh
+++ b/src/misc.hh
@@ -184,6 +184,20 @@ size_t count_gbuffer_array_layers(const std::vector<T>& targets)
 void profile_tick();
 void profile_tock(const char* message = "Tock: ");
 
+template<typename T>
+void set_debug_object_name(const tr::device& device, const T& vulkan_object, const char* name)
+{
+    assert(device.ctx);
+    if (device.ctx->has_validation())
+    {
+        vk::DebugUtilsObjectNameInfoEXT info{};
+        info.objectHandle = (uint64_t)static_cast<T::CType>(vulkan_object);
+        info.objectType = vulkan_object.objectType;
+        info.pObjectName = name;
+        device.logical.setDebugUtilsObjectNameEXT(&info);
+    }
+}
+
 }
 
 #endif


### PR DESCRIPTION
Suggestion to add debug object names to Vulkan objects using [https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectNameEXT.html](vkSetDebugUtilsObjectNameEXT) to help with debugging using validation layers.

This commit adds them to the GBuffer render targets.