### PR TITLE
Skip software drivers when ray tracing

### DIFF
--- a/src/context.cc
+++ b/src/context.cc
@@ -431,6 +431,9 @@ void context::init_devices()
         if(props.apiVersion < VK_API_VERSION_1_2)
             continue;
 
+        if(props.deviceType == vk::PhysicalDeviceType::eCpu && !opt.disable_ray_tracing)
+            continue;
+
         auto feats_pack = physical.getFeatures2<
             vk::PhysicalDeviceFeatures2,
             vk::PhysicalDeviceVulkan11Features,


### PR DESCRIPTION
Lavapipe advertises ray tracing support since Mesa 24.1, skip it.

The raster renderer runs at interactive speeds with lavapipe so software drivers are still allowed there.